### PR TITLE
Maven configuration to enable publishing binaries to Sonatype repository.

### DIFF
--- a/credentials/pom.xml
+++ b/credentials/pom.xml
@@ -13,8 +13,33 @@
   <artifactId>google-auth-library-credentials</artifactId>
   <name>Google Auth Library for Java - Credentials</name>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <build>
     <sourceDirectory>java</sourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
 
 </project>

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -13,9 +13,34 @@
   <artifactId>google-auth-library-oauth2-http</artifactId>
   <name>Google Auth Library for Java - OAuth2 HTTP</name>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <build>
     <sourceDirectory>java</sourceDirectory>
     <testSourceDirectory>javatests</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,9 @@
   <version>0.1.0</version>
   <packaging>pom</packaging>
   <name>Google Auth Library for Java</name>
+  <description>Client libraries providing authentication and
+    authorization to enable calling Google APIs.</description>
+  <url>https://github.com/google/google-auth-library-java</url>
 
   <licenses>
     <license>
@@ -34,6 +37,8 @@
   </modules>
 
   <scm>
+    <connection>scm:git:https://github.com/google/google-auth-library-java.git</connection>
+    <developerConnection>scm:git:https://github.com/google/google-auth-library-java.git</developerConnection>
     <url>https://github.com/google/google-auth-library-java</url>
   </scm>
 
@@ -76,5 +81,64 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <!-- This is the parent, so only define pluginManagement, not plugins. -->
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.6.3</version>
+          <extensions>true</extensions>
+          <configuration>
+            <serverId>ossrh</serverId>
+            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.2.1</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.9.1</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.5</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 
 </project>


### PR DESCRIPTION
Tooling configuration to allow automated deployment of binary releases to https://oss.sonatype.org. Some additional metadata to satisfy requirements.