### PR TITLE
Google App Engine Credentials.

### DIFF
--- a/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
+++ b/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.appengine;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.collect.ImmutableList;
+import com.google.appengine.api.appidentity.AppIdentityService;
+import com.google.appengine.api.appidentity.AppIdentityServiceFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * OAuth2 credentials representing the built-in service account for Google App ENgine.
+ *
+ * <p>Fetches access tokens from the App Identity service.
+ */
+public class AppEngineCredentials extends GoogleCredentials {
+  
+  private final AppIdentityService appIdentityService;
+  
+  private final Collection<String> scopes;
+  
+  private final boolean scopesRequired;  
+  
+  public AppEngineCredentials(Collection<String> scopes) {
+    this(scopes, null);
+  }
+
+  public AppEngineCredentials(Collection<String> scopes, AppIdentityService appIdentityService) {
+    this.scopes = ImmutableList.copyOf(scopes);
+    this.appIdentityService = appIdentityService != null ? appIdentityService 
+        : AppIdentityServiceFactory.getAppIdentityService();
+    scopesRequired = (scopes == null || scopes.isEmpty());
+  }
+  
+  /**
+   * Refresh the access token by getting it from the App Identity service
+   */
+  @Override
+  public AccessToken refreshAccessToken() throws IOException {
+    if (createScopedRequired()) {
+      throw new IOException("AppEngineCredentials requires createScoped call before use.");
+    }
+    String accessToken = appIdentityService.getAccessToken(scopes).getAccessToken();
+    return new AccessToken(accessToken, null);    
+  }
+  
+  @Override
+  public boolean createScopedRequired() {
+    return scopesRequired;
+  }
+
+  @Override
+  public GoogleCredentials createScoped(Collection<String> scopes) {
+    return new AppEngineCredentials(scopes, appIdentityService);
+  }    
+}

--- a/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
+++ b/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.appengine;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotSame;
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for AppEngineCredentials
+ */
+@RunWith(JUnit4.class)
+public class AppEngineCredentialsTest {
+  
+  private static final Collection<String> SCOPES =
+      Collections.unmodifiableCollection(Arrays.asList("scope1", "scope2"));
+  private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
+  
+  @Test  
+  public void constructor_usesAppIdentityService() throws IOException {
+    final String expectedAccessToken = "ExpectedAccessToken";
+
+    MockAppIdentityService appIdentity = new MockAppIdentityService();
+    appIdentity.setAccessTokenText(expectedAccessToken);
+    Credentials credentials = new AppEngineCredentials(SCOPES, appIdentity);
+
+    Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
+
+    assertEquals(1, appIdentity.getGetAccessTokenCallCount());
+    assertContainsBearerToken(metadata, expectedAccessToken);
+  }
+
+  @Test  
+  public void createScoped_clonesWithScopes() throws IOException {
+    final String expectedAccessToken = "ExpectedAccessToken";
+    final Collection<String> emptyScopes = Collections.emptyList();
+
+    MockAppIdentityService appIdentity = new MockAppIdentityService();
+    appIdentity.setAccessTokenText(expectedAccessToken);
+
+    GoogleCredentials credentials = new AppEngineCredentials(emptyScopes, appIdentity);
+    
+    assertTrue(credentials.createScopedRequired());
+    try {
+      credentials.getRequestMetadata(CALL_URI);
+      fail("Should not be able to use credential without scopes.");
+    } catch (Exception expected) {
+    }
+    assertEquals(0, appIdentity.getGetAccessTokenCallCount());
+
+    GoogleCredentials scopedCredentials = credentials.createScoped(SCOPES);
+    assertNotSame(credentials, scopedCredentials);
+    
+    Map<String, List<String>> metadata = scopedCredentials.getRequestMetadata(CALL_URI);
+
+    assertEquals(1, appIdentity.getGetAccessTokenCallCount());
+    assertContainsBearerToken(metadata, expectedAccessToken);
+  }
+  
+  private static void assertContainsBearerToken(Map<String, List<String>> metadata, String token) {
+    assertNotNull(metadata);
+    assertNotNull(token);
+    String expectedValue = "Bearer " + token;
+    List<String> authorizations = metadata.get("Authorization");
+    assertNotNull("Authorization headers not found", authorizations);
+    boolean found = false;
+    for (String authorization : authorizations) {
+      if (expectedValue.equals(authorization)) {
+        found = true;
+        break;
+      }
+    }
+    assertTrue("Bearer token not found", found);
+  }
+}

--- a/appengine/javatests/com/google/auth/appengine/MockAppIdentityService.java
+++ b/appengine/javatests/com/google/auth/appengine/MockAppIdentityService.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.appengine;
+
+import com.google.appengine.api.appidentity.AppIdentityService;
+import com.google.appengine.api.appidentity.AppIdentityServiceFailureException;
+import com.google.appengine.api.appidentity.PublicCertificate;
+
+import java.util.Collection;
+
+/**
+ * Mock implementation of AppIdentityService interface for testing.
+ */
+public class MockAppIdentityService implements AppIdentityService {
+
+  private int getAccessTokenCallCount = 0;
+  private String accessTokenText = null;
+
+  public MockAppIdentityService() {
+  }
+
+  public int getGetAccessTokenCallCount() {
+    return getAccessTokenCallCount;
+  }
+
+  public String getAccessTokenText() {
+    return accessTokenText;
+  }
+
+  public void setAccessTokenText(String text) {
+    accessTokenText = text;
+  }
+
+  public SigningResult signForApp(byte[] signBlob) {
+    return null;
+  }
+
+  public Collection<PublicCertificate> getPublicCertificatesForApp() {
+    return null;
+  }
+
+  public GetAccessTokenResult getAccessToken(Iterable<String> scopes) {
+    getAccessTokenCallCount++;
+    int scopeCount = 0;
+    for (String scope : scopes) {
+      if (scope != null) {
+        scopeCount++;
+      }
+    }
+    if (scopeCount == 0) {
+      throw new AppIdentityServiceFailureException("No scopes specified.");
+    }
+    return new GetAccessTokenResult(accessTokenText, null);
+  }
+
+  public GetAccessTokenResult getAccessTokenUncached(Iterable<String> scopes) {
+    return null;
+  }
+
+  public String getServiceAccountName() {
+    return null;
+  }
+
+  public ParsedAppId parseFullAppId(String fullAppId) {
+    return null;
+  }
+
+  public String getDefaultGcsBucketName() {
+    return null;
+  }
+}

--- a/appengine/pom.xml
+++ b/appengine/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.auth</groupId>
+    <artifactId>google-auth-library-parent</artifactId>
+    <version>0.2.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>google-auth-library-appengine</artifactId>
+  <name>Google Auth Library for Java - Google App Engine</name>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <build>
+    <sourceDirectory>java</sourceDirectory>
+    <testSourceDirectory>javatests</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+    </dependency>    
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-jdk5</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
   <modules>
     <module>credentials</module>
     <module>oauth2_http</module>
+    <module>appengine</module>
   </modules>
 
   <scm>
@@ -48,6 +49,7 @@
     <project.google.http.version>1.19.0</project.google.http.version>
     <project.junit.version>4.8.2</project.junit.version>
     <project.guava.version>13.0</project.guava.version>
+    <project.appengine.version>1.9.21</project.appengine.version>
   </properties>
 
   <dependencyManagement>
@@ -55,6 +57,11 @@
       <dependency>
         <groupId>com.google.auth</groupId>
         <artifactId>google-auth-library-credentials</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-oauth2-http</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -67,6 +74,11 @@
         <artifactId>google-http-client-jackson2</artifactId>
         <version>${project.google.http.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.google.appengine</groupId>
+        <artifactId>appengine-api-1.0-sdk</artifactId>
+        <version>${project.appengine.version}</version>
+      </dependency>      
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>


### PR DESCRIPTION
Initial implementation of AppEngineCredentials in new module because of GAE SDK dependencies.