### PR TITLE
Fixing https://github.com/google/google-auth-library-java/issues/22

### DIFF
--- a/oauth2_http/java/com/google/auth/http/AuthHttpConstants.java
+++ b/oauth2_http/java/com/google/auth/http/AuthHttpConstants.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.http;
+
+/**
+ * Constants used for auth in http
+ */
+public class AuthHttpConstants {
+  /**
+   * HTTP "Bearer" authentication scheme
+   */
+  public static final String BEARER = "Bearer";
+
+  /**
+   * HTTP "Authentication" header
+   */
+  public static final String AUTHORIZATION = "Authorization";
+}

--- a/oauth2_http/java/com/google/auth/http/HttpCredentialsAdapter.java
+++ b/oauth2_http/java/com/google/auth/http/HttpCredentialsAdapter.java
@@ -4,6 +4,9 @@ import com.google.auth.Credentials;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.HttpUnsuccessfulResponseHandler;
 import com.google.api.client.util.Preconditions;
 
 import java.io.IOException;
@@ -11,11 +14,24 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 /**
  * A wrapper for using Credentials with the Google API Client Libraries for Java with Http.
  */
-public class HttpCredentialsAdapter implements HttpRequestInitializer {
+public class HttpCredentialsAdapter
+    implements HttpRequestInitializer, HttpUnsuccessfulResponseHandler {
+
+  private static final Logger LOGGER = Logger.getLogger(HttpCredentialsAdapter.class.getName());
+
+  /**
+   * In case an abnormal HTTP response is received with {@code WWW-Authenticate} header, and its
+   * value contains this error pattern, we will try to refresh the token.
+   */
+  private static final Pattern INVALID_TOKEN_ERROR =
+      Pattern.compile("\\s*error\\s*=\\s*\"?invalid_token\"?");
 
   private final Credentials credentials;
 
@@ -27,12 +43,16 @@ public class HttpCredentialsAdapter implements HttpRequestInitializer {
     this.credentials = credentials;
   }
 
-    /**
-     * Initialize the HTTP request prior to execution.
-     *
-     * @param request HTTP request
-     */
+  /**
+   * {@inheritDoc}
+   *
+   * Initialize the HTTP request prior to execution.
+   *
+   * @param request HTTP request
+   */
   public void initialize(HttpRequest request) throws IOException {
+    request.setUnsuccessfulResponseHandler(this);
+
     if (!credentials.hasRequestMetadata()) {
       return;
     }
@@ -44,16 +64,57 @@ public class HttpCredentialsAdapter implements HttpRequestInitializer {
     }
     for (Map.Entry<String, List<String>> entry : credentialHeaders.entrySet()) {
       String headerName = entry.getKey();
-      List<String> requestValues = getHeadersValue(requestHeaders, headerName);
-      if (requestValues == null) {
-        requestValues = new ArrayList<String>();
-        requestHeaders.put(headerName, requestValues);
-      }
-      List<String> credentialValues = entry.getValue();
-      for (String credentialValue : credentialValues) {
-        requestValues.add(credentialValue);
+      List<String> requestValues = new ArrayList<String>();
+      requestValues.addAll(entry.getValue());
+      requestHeaders.put(headerName, requestValues);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Checks if {@code WWW-Authenticate} exists and contains a "Bearer" value
+   * (see <a href="http://tools.ietf.org/html/rfc6750#section-3.1">rfc6750 section 3.1</a> for more
+   * details). If so, it refreshes the token in case the error code contains
+   * {@code invalid_token}. If there is no "Bearer" in {@code WWW-Authenticate} and the status code
+   * is {@link HttpStatusCodes#STATUS_CODE_UNAUTHORIZED} it refreshes the token. If
+   * the token refresh throws an I/O exception, this implementation will log the
+   * exception and return {@code false}.
+   * </p>
+   */
+  public boolean handleResponse(HttpRequest request, HttpResponse response, boolean supportsRetry) {
+    boolean refreshToken = false;
+    boolean bearer = false;
+
+    List<String> authenticateList = response.getHeaders().getAuthenticateAsList();
+
+    // if authenticate list is not null we will check if one of the entries contains "Bearer"
+    if (authenticateList != null) {
+      for (String authenticate : authenticateList) {
+        if (authenticate.startsWith(InternalAuthHttpConstants.BEARER_PREFIX)) {
+          // mark that we found a "Bearer" value, and check if there is a invalid_token error
+          bearer = true;
+          refreshToken = INVALID_TOKEN_ERROR.matcher(authenticate).find();
+          break;
+        }
       }
     }
+
+    // if "Bearer" wasn't found, we will refresh the token, if we got 401
+    if (!bearer) {
+      refreshToken = response.getStatusCode() == HttpStatusCodes.STATUS_CODE_UNAUTHORIZED;
+    }
+
+    if (refreshToken) {
+      try {
+        credentials.refresh();
+        initialize(request);
+        return true;
+      } catch (IOException exception) {
+        LOGGER.log(Level.SEVERE, "unable to refresh token", exception);
+      }
+    }
+    return false;
   }
 
   // Get header value, casting to List<String>.

--- a/oauth2_http/java/com/google/auth/http/InternalAuthHttpConstants.java
+++ b/oauth2_http/java/com/google/auth/http/InternalAuthHttpConstants.java
@@ -1,0 +1,8 @@
+package com.google.auth.http;
+
+/**
+ * Internal constants used for auth in http
+ */
+class InternalAuthHttpConstants {
+  static final String BEARER_PREFIX = AuthHttpConstants.BEARER + " ";
+}

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -2,6 +2,7 @@ package com.google.auth.oauth2;
 
 import com.google.api.client.util.Clock;
 import com.google.auth.Credentials;
+import com.google.auth.http.AuthHttpConstants;
 
 import java.io.IOException;
 import java.net.URI;
@@ -22,7 +23,7 @@ public abstract class OAuth2Credentials extends Credentials {
   private Map<String, List<String>> requestMetadata;
   private AccessToken temporaryAccess;
 
-  // Allow clock to be overriden by test code
+  // Allow clock to be overridden by test code
   Clock clock = Clock.SYSTEM;
 
   @Override
@@ -55,9 +56,9 @@ public abstract class OAuth2Credentials extends Credentials {
       if (requestMetadata == null) {
         Map<String, List<String>> newRequestMetadata = new HashMap<String, List<String>>();
         List<String> newAuthorizationHeaders = new ArrayList<String>();
-        String authorizationHeader = "Bearer " + temporaryAccess.getTokenValue();
+        String authorizationHeader = OAuth2Utils.BEARER_PREFIX + temporaryAccess.getTokenValue();
         newAuthorizationHeaders.add(authorizationHeader);
-        newRequestMetadata.put("Authorization", newAuthorizationHeaders);
+        newRequestMetadata.put(AuthHttpConstants.AUTHORIZATION, newAuthorizationHeaders);
         requestMetadata = newRequestMetadata;
       }
       return requestMetadata;

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
@@ -6,6 +6,7 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.GenericData;
+import com.google.auth.http.AuthHttpConstants;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -26,6 +27,8 @@ class OAuth2Utils {
 
   private static String VALUE_NOT_FOUND_MESSAGE = "%sExpected value %s not found.";
   private static String VALUE_WRONG_TYPE_MESSAGE = "%sExpected %s value %s of wrong type.";
+
+  static final String BEARER_PREFIX = AuthHttpConstants.BEARER + " ";
 
   /**
    * Returns whether the headers contain the specified value as one of the entries in the

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -37,6 +37,7 @@ import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.api.client.util.Clock;
 import com.google.api.client.util.Preconditions;
 import com.google.auth.Credentials;
+import com.google.auth.http.AuthHttpConstants;
 
 import java.io.IOException;
 import java.net.URI;
@@ -186,10 +187,10 @@ public class ServiceAccountJwtAccessCredentials extends Credentials {
       }
     }
     String assertion = getJwtAccess(uri);
-    String authorizationHeader = "Bearer #" + assertion;
+    String authorizationHeader = OAuth2Utils.BEARER_PREFIX + "#" + assertion;
     List<String> newAuthorizationHeaders = Collections.singletonList(authorizationHeader);
     Map<String, List<String>> newRequestMetadata =
-        Collections.singletonMap("Authorization", newAuthorizationHeaders);
+        Collections.singletonMap(AuthHttpConstants.AUTHORIZATION, newAuthorizationHeaders);
     return newRequestMetadata;
   }
 

--- a/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -94,7 +94,7 @@ public class UserCredentials extends GoogleCredentials {
   }
 
   /**
-   * Refreshes the OAuth2 acces token by getting a new access token from the refresh token
+   * Refreshes the OAuth2 access token by getting a new access token from the refresh token
    */
   @Override
   public AccessToken refreshAccessToken() throws IOException {

--- a/oauth2_http/javatests/com/google/auth/TestUtils.java
+++ b/oauth2_http/javatests/com/google/auth/TestUtils.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.auth.http.AuthHttpConstants;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 
@@ -29,8 +30,8 @@ public class TestUtils {
   public static void assertContainsBearerToken(Map<String, List<String>> metadata, String token) {
     assertNotNull(metadata);
     assertNotNull(token);
-    String expectedValue = "Bearer " + token;
-    List<String> authorizations = metadata.get("Authorization");
+    String expectedValue = AuthHttpConstants.BEARER + " " + token;
+    List<String> authorizations = metadata.get(AuthHttpConstants.AUTHORIZATION);
     assertNotNull("Authorization headers not found", authorizations);
     boolean found = false;
     for (String authorization : authorizations) {

--- a/oauth2_http/javatests/com/google/auth/http/HttpCredentialsAdapterTest.java
+++ b/oauth2_http/javatests/com/google/auth/http/HttpCredentialsAdapterTest.java
@@ -6,6 +6,9 @@ import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpTransport;
+import com.google.auth.oauth2.MockTokenCheckingTransport;
 import com.google.auth.oauth2.MockTokenServerTransport;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.auth.oauth2.UserCredentials;
@@ -29,7 +32,7 @@ public class HttpCredentialsAdapterTest {
   @Test
   public void initialize_populatesOAuth2Credentials() throws IOException {
     final String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    final String expectedAuthorization = "Bearer " + accessToken;
+    final String expectedAuthorization = InternalAuthHttpConstants.BEARER_PREFIX + accessToken;
     MockTokenServerTransport transport = new MockTokenServerTransport();
     transport.addClient(CLIENT_ID, CLIENT_SECRET);
     transport.addRefreshToken(REFRESH_TOKEN, accessToken);
@@ -44,5 +47,37 @@ public class HttpCredentialsAdapterTest {
     HttpHeaders requestHeaders = request.getHeaders();
     String authorizationHeader = requestHeaders.getAuthorization();
     assertEquals(authorizationHeader, expectedAuthorization);
+  }
+
+  @Test
+  public void initialize_populatesOAuth2Credentials_handle401() throws IOException {
+    final String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
+    final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
+    final String expectedAuthorization = InternalAuthHttpConstants.BEARER_PREFIX + accessToken;
+
+    final MockTokenServerTransport tokenServerTransport = new MockTokenServerTransport();
+    tokenServerTransport.addClient(CLIENT_ID, CLIENT_SECRET);
+    tokenServerTransport.addRefreshToken(REFRESH_TOKEN, accessToken);
+
+    OAuth2Credentials credentials = new UserCredentials(
+        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, tokenServerTransport);
+    credentials.refresh();
+    HttpCredentialsAdapter adapter = new HttpCredentialsAdapter(credentials);
+
+    HttpTransport primaryHttpTransport =
+        new MockTokenCheckingTransport(tokenServerTransport, REFRESH_TOKEN);
+    HttpRequestFactory requestFactory = primaryHttpTransport.createRequestFactory();
+    HttpRequest request = requestFactory.buildGetRequest(new GenericUrl("http://foo"));
+    adapter.initialize(request);
+
+    // now switch out the access token so that the original one is invalid,
+    //   requiring a refresh of the access token
+    tokenServerTransport.addRefreshToken(REFRESH_TOKEN, accessToken2);
+
+    HttpResponse response = request.execute();
+
+    // make sure that the request is successful despite the invalid access token
+    assertEquals(200, response.getStatusCode());
+    assertEquals(MockTokenCheckingTransport.SUCCESS_CONTENT, response.parseAsString());
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenCheckingTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenCheckingTransport.java
@@ -1,0 +1,69 @@
+package com.google.auth.oauth2;
+
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.Json;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.auth.http.AuthHttpConstants;
+
+import java.io.IOException;
+
+/**
+ * Mock transport to simulate an http server that checks tokens
+ */
+public class MockTokenCheckingTransport extends HttpTransport {
+
+  public static final String SUCCESS_CONTENT = "{\"key\":\"value\"}";
+
+  private MockTokenServerTransport tokenServer;
+  private String refreshToken;
+
+  public MockTokenCheckingTransport(MockTokenServerTransport tokenServer,
+                                    String refreshToken) {
+    this.tokenServer = tokenServer;
+    this.refreshToken = refreshToken;
+  }
+
+  @Override
+  public MockLowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+    return new MockLowLevelHttpRequest() {
+      @Override
+      public MockLowLevelHttpResponse execute() throws IOException {
+        String credentialValue = getFirstHeaderValue(AuthHttpConstants.AUTHORIZATION);
+        String correctAccessToken = tokenServer.getAccessToken(refreshToken);
+        if (credentialValue == null) {
+          return makeErrorResponse();
+        }
+        if (!credentialValue.startsWith(OAuth2Utils.BEARER_PREFIX)) {
+          return makeErrorResponse();
+        }
+        String actualAccessToken = credentialValue.substring(OAuth2Utils.BEARER_PREFIX.length());
+        if (!correctAccessToken.equals(actualAccessToken)) {
+          return makeErrorResponse();
+        } else {
+          return makeSuccessResponse();
+        }
+      }
+    };
+  }
+
+  private MockLowLevelHttpResponse makeErrorResponse() {
+    MockLowLevelHttpResponse errorResponse = new MockLowLevelHttpResponse();
+    errorResponse.addHeader("custom_header", "value");
+    errorResponse.setStatusCode(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
+    errorResponse.setContentType(Json.MEDIA_TYPE);
+    errorResponse.setContent("{\"error\":\"invalid credentials\"}");
+    return errorResponse;
+  }
+
+  private MockLowLevelHttpResponse makeSuccessResponse() {
+    MockLowLevelHttpResponse successResponse = new MockLowLevelHttpResponse();
+    successResponse.addHeader("custom_header", "value");
+    successResponse.setStatusCode(HttpStatusCodes.STATUS_CODE_OK);
+    successResponse.setContentType(Json.MEDIA_TYPE);
+    successResponse.setContent(SUCCESS_CONTENT);
+    return successResponse;
+  }
+
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -1,5 +1,6 @@
 package com.google.auth.oauth2;
 
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.LowLevelHttpRequest;
 import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.json.GenericJson;
@@ -15,6 +16,8 @@ import com.google.auth.TestUtils;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
+import java.lang.UnsupportedOperationException;
 
 /**
  * Mock transport to simulate providing Google OAuth2 access tokens
@@ -40,6 +43,10 @@ public class MockTokenServerTransport extends MockHttpTransport {
 
   public void addServiceAccount(String email, String accessToken) {
     serviceAccounts.put(email, accessToken);
+  }
+
+  public String getAccessToken(String refreshToken) {
+    return refreshTokens.get(refreshToken);
   }
 
   @Override

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -41,6 +41,7 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.auth.Credentials;
+import com.google.auth.http.AuthHttpConstants;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -154,7 +155,7 @@ public class ServiceAccountJwtAccessCredentialsTest {
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     assertNotNull(metadata);    
-    List<String> authorizations = metadata.get("Authorization");
+    List<String> authorizations = metadata.get(AuthHttpConstants.AUTHORIZATION);
     assertNotNull("Authorization headers not found", authorizations);
     String assertion = null;
     for (String authorization : authorizations) {
@@ -180,7 +181,7 @@ public class ServiceAccountJwtAccessCredentialsTest {
     Map<String, List<String>> metadata = credentials.getRequestMetadata();
 
     assertNotNull(metadata);    
-    List<String> authorizations = metadata.get("Authorization");
+    List<String> authorizations = metadata.get(AuthHttpConstants.AUTHORIZATION);
     assertNotNull("Authorization headers not found", authorizations);
     String assertion = null;
     for (String authorization : authorizations) {


### PR DESCRIPTION
Some additional stuff:
* Creating some constants so that hardcoded values aren't repeated
* Fixing a couple spelling errors
* Having MockTokenServerTransport extend HttpTransport directly, since it doesn't use anything from MockHttpTransport
