### PR TITLE
Enable temporary access token scenario

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -13,7 +13,7 @@ import java.util.Collection;
 /**
  * Base type for credentials for authorizing calls to Google APIs using OAuth2.
  */
-public abstract class GoogleCredentials extends OAuth2Credentials {
+public class GoogleCredentials extends OAuth2Credentials {
 
   static final String USER_FILE_TYPE = "authorized_user";
   static final String SERVICE_ACCOUNT_FILE_TYPE = "service_account";
@@ -108,7 +108,7 @@ public abstract class GoogleCredentials extends OAuth2Credentials {
   /**
    * Default constructor.
    **/
-  public GoogleCredentials() {
+  protected GoogleCredentials() {
     this(null);
   }
 

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -15,7 +15,7 @@ import java.util.Map;
 /**
  * Base type for Credentials using OAuth2.
  */
-public abstract class OAuth2Credentials extends Credentials {
+public class OAuth2Credentials extends Credentials {
 
   private static final int MINIMUM_TOKEN_MILLISECONDS = 60000;
 
@@ -29,7 +29,7 @@ public abstract class OAuth2Credentials extends Credentials {
   /**
    * Default constructor.
    **/
-  public OAuth2Credentials() {
+  protected OAuth2Credentials() {
     this(null);
   }
 
@@ -55,6 +55,10 @@ public abstract class OAuth2Credentials extends Credentials {
   @Override
   public boolean hasRequestMetadataOnly() {
     return true;
+  }
+
+  public final AccessToken getAccessToken() {
+    return temporaryAccess;
   }
 
   /**
@@ -94,9 +98,18 @@ public abstract class OAuth2Credentials extends Credentials {
   }
 
   /**
-   * Abstract method to refresh the access token according to the specific type of credentials.
+   * Method to refresh the access token according to the specific type of credentials.
+   *
+   * Throws IllegalStateException if not overridden since direct use of OAuth2Credentials is only
+   * for temporary or non-refreshing access tokens.
+   *
+   * @throws IOException from derived implementations
    */
-  public abstract AccessToken refreshAccessToken() throws IOException;
+  public AccessToken refreshAccessToken() throws IOException {
+    throw new IllegalStateException("OAuth2Credentials instance does not support refreshing the"
+        + " access token. An instance with a new access token should be used, or a derived type"
+        + " that supports refreshing should be used.");
+  }
 
   /**
    * Return the remaining time the current access token will be valid, or null if there is no

--- a/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
@@ -24,7 +24,15 @@ public class OAuth2CredentialsTest {
   private static final String CLIENT_SECRET = "jakuaL9YyieakhECKL2SwZcu";
   private static final String CLIENT_ID = "ya29.1.AADtN_UtlxN3PuGAxrN2XQnZTVRvDyVWnYq4I6dws";
   private static final String REFRESH_TOKEN = "1/Tl6awhpFjkMkSJoj1xsli0H2eL5YsMgU_NKPY2TyGWY";
+  private static final String ACCESS_TOKEN = "aashpFjkMkSJoj1xsli0H2eL5YsMgU_NKPY2TyGWY";
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
+
+  @Test
+  public void constructor_storesAccessToken() {
+    OAuth2Credentials credentials = new OAuth2Credentials(new AccessToken(ACCESS_TOKEN, null));
+
+    assertEquals(credentials.getAccessToken().getTokenValue(), ACCESS_TOKEN);
+  }
 
   @Test
   public void getAuthenticationType_returnsOAuth2() {
@@ -75,6 +83,15 @@ public class OAuth2CredentialsTest {
   }
 
   @Test
+  public void getRequestMetadata_temporaryToken_hasToken() throws IOException {
+    OAuth2Credentials credentials = new OAuth2Credentials(new AccessToken(ACCESS_TOKEN, null));
+
+    // Verify getting the first token
+    Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
+  }
+
+  @Test
   public void refresh_refreshesToken() throws IOException {
     final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
     final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
@@ -100,5 +117,11 @@ public class OAuth2CredentialsTest {
     userCredentials.refresh();
     metadata = userCredentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, accessToken2);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void refresh_temporaryToken_throws() throws IOException {
+    OAuth2Credentials credentials = new OAuth2Credentials(new AccessToken(ACCESS_TOKEN, null));
+    credentials.refresh();
   }
 }


### PR DESCRIPTION
Enables direct use of temporary access tokens by making OAuth2Credentials non-abstract.