### PR TITLE
Bump nexus-staging-maven-plugin to 1.6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava-jdk5</artifactId>
         <version>${project.guava.version}</version>
-      </dependency>            
+      </dependency>
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
@@ -104,7 +104,7 @@
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.3</version>
+          <version>1.6.5</version>
           <extensions>true</extensions>
           <configuration>
             <serverId>ossrh</serverId>


### PR DESCRIPTION
The old version, 1.6.3, throws ArrayIndexOutOfBounds under Java 8 when
executing "vn nexus-staging:release -DperformRelease=true".

Newer versions fixes this problem. See:
https://issues.sonatype.org/browse/NEXUS-6836 .