### PR TITLE
Using Objects for the List type in CloudShellCredentials.

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
@@ -32,13 +32,14 @@
 package com.google.auth.oauth2;
 
 import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.JsonParser;
+
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.Socket;
-import java.util.Collection;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -83,9 +84,9 @@ public class CloudShellCredentials extends GoogleCredentials {
       BufferedReader input =
           new BufferedReader(new InputStreamReader(socket.getInputStream()));
       input.readLine(); // Skip over the first line
-      Collection<String> messageArray = jsonFactory.createJsonParser(input)
-        .parseArray(LinkedList.class, String.class);
-      String accessToken = ((List<String>) messageArray).get(ACCESS_TOKEN_INDEX);
+      JsonParser parser = jsonFactory.createJsonParser(input);
+      List<Object> messageArray = (List<Object>) parser.parseArray(ArrayList.class, Object.class);
+      String accessToken = messageArray.get(ACCESS_TOKEN_INDEX).toString();
       token =  new AccessToken(accessToken, null);
     } finally {
       socket.close();


### PR DESCRIPTION
The Json for shell credentials returns a double for the last item in the list.  I kept on getting the following exception before this change:

2015-12-16 11:29:45,550 INFO  [BigtableSession-startup-0] grpc.BigtableSession: gRPC is using the JDK provider (alpn-boot jar)
2015-12-16 11:29:52,543 INFO  [bigtable-connection-shared-executor-pool1-t2] io.RefreshingOAuth2CredentialsInterceptor: Refreshing the OAuth token
2015-12-16 11:29:53,798 WARN  [bigtable-connection-shared-executor-pool1-t2] io.RefreshingOAuth2CredentialsInterceptor: Got an unexpected exception while trying to refresh google credentials.
java.lang.IllegalArgumentException:
        at com.google.bigtable.repackaged.com.google.api.client.json.JsonParser.parseValue(JsonParser.java:871)
        at com.google.bigtable.repackaged.com.google.api.client.json.JsonParser.parseArray(JsonParser.java:638)
        at com.google.bigtable.repackaged.com.google.api.client.json.JsonParser.parseArray(JsonParser.java:618)
        at com.google.bigtable.repackaged.com.google.api.client.json.JsonParser.parseArray(JsonParser.java:587)
        at com.google.bigtable.repackaged.com.google.api.client.json.JsonParser.parseArray(JsonParser.java:567)
        at com.google.bigtable.repackaged.com.google.auth.oauth2.CloudShellCredentials.refreshAccessToken(CloudShellCredentials.java:87)
        at com.google.cloud.bigtable.grpc.io.RefreshingOAuth2CredentialsInterceptor.refreshCredentialsWithRetry(RefreshingOAuth2CredentialsInterceptor.
java:268)
        at com.google.cloud.bigtable.grpc.io.RefreshingOAuth2CredentialsInterceptor.doRefresh(RefreshingOAuth2CredentialsInterceptor.java:238)
        at com.google.cloud.bigtable.grpc.io.RefreshingOAuth2CredentialsInterceptor$1.run(RefreshingOAuth2CredentialsInterceptor.java:166)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalArgumentException: expected numeric type but got class java.lang.String
        at com.google.bigtable.repackaged.com.google.api.client.json.JsonParser.parseValue(JsonParser.java:834)
        ... 11 more