### PR TITLE
Deprecate X-Google-Metadata-Request in favor new Metadata-Flavor header

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -54,7 +54,7 @@ public class ComputeEngineCredentials extends GoogleCredentials {
     HttpRequest request = transport.createRequestFactory().buildGetRequest(tokenUrl);
     JsonObjectParser parser = new JsonObjectParser(OAuth2Utils.JSON_FACTORY);
     request.setParser(parser);
-    request.getHeaders().set("X-Google-Metadata-Request", true);
+    request.getHeaders().set("Metadata-Flavor", "Google");
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = null;
     try {

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
@@ -45,8 +45,8 @@ public class MockMetadataServerTransport extends MockHttpTransport {
             return response;
           }
 
-          String metadataRequestHeader = getFirstHeaderValue("X-Google-Metadata-Request");
-          if (!"true".equals(metadataRequestHeader)) {
+          String metadataRequestHeader = getFirstHeaderValue("Metadata-Flavor");
+          if (!"Google".equals(metadataRequestHeader)) {
             throw new IOException("Metadata request header not found.");
           }
 


### PR DESCRIPTION
We are deprecating the use of the X-Google-Metadata-Request header in favor
of the latest header, Metadata-Flavor.

The transition is explained here:

https://cloud.google.com/compute/docs/metadata#transitioning