### PR TITLE
Standardize the naming convention of base64-encoded binary data.

### DIFF
--- a/credentials/java/com/google/auth/Credentials.java
+++ b/credentials/java/com/google/auth/Credentials.java
@@ -26,6 +26,9 @@ public abstract class Credentials {
    * populated in headers or other context. The operation can block and fail to complete and may do
    * things such as refreshing access tokens.
    *
+   * <p>The convention for handling binary data is for the key in the returned map to end with
+   * {@code "-bin"} and for the corresponding values to be base64 encoded.
+   *
    * @throws IOException if there was an error getting up-to-date access.
    */
   public Map<String, List<String>> getRequestMetadata() throws IOException {
@@ -38,6 +41,9 @@ public abstract class Credentials {
    * <p>This should be called by the transport layer on each request, and the data should be
    * populated in headers or other context. The operation can block and fail to complete and may do
    * things such as refreshing access tokens.
+   *
+   * <p>The convention for handling binary data is for the key in the returned map to end with
+   * {@code "-bin"} and for the corresponding values to be base64 encoded.
    *
    * @param uri URI of the entry point for the request.
    * @throws IOException if there was an error getting up-to-date access.


### PR DESCRIPTION
I am working on populating our internal (prod) authentication object onto wire in gRPC.  I am going to use `Credentials`, and because the authentication object is serialized as binary headers, I will base64-encode them.

The `Credentials` object will be passed to gRPC `ClientAuthInterceptor` and populated to gRPC `Metadata`, which accepts binary value (`byte[]`) when the key ends with `"-bin"`, and string value otherwise.  Therefore, `ClientAuthInterceptor` needs to decode the base64-encoded binary headers returned by `Crendentials`, and pass through the others.

`ClientAuthInterceptor` could use `"-bin"` as the indicator. However, because it consumes any `Crendentials` implementation, it's not safe for it to rely on this indicator unless it's defined on the `Credentials` interface.

This is a documentation-only no-op change.  I have talked with @ejona86, and he is OK with this change.