### PR TITLE
Adding expiration date to AppEngineCredentials.

### DIFF
--- a/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
+++ b/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
@@ -35,10 +35,12 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableList;
 import com.google.appengine.api.appidentity.AppIdentityService;
+import com.google.appengine.api.appidentity.AppIdentityService.GetAccessTokenResult;
 import com.google.appengine.api.appidentity.AppIdentityServiceFactory;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Date;
 
 /**
  * OAuth2 credentials representing the built-in service account for Google App ENgine.
@@ -72,8 +74,10 @@ public class AppEngineCredentials extends GoogleCredentials {
     if (createScopedRequired()) {
       throw new IOException("AppEngineCredentials requires createScoped call before use.");
     }
-    String accessToken = appIdentityService.getAccessToken(scopes).getAccessToken();
-    return new AccessToken(accessToken, null);    
+    GetAccessTokenResult accessTokenResponse = appIdentityService.getAccessToken(scopes);
+    String accessToken = accessTokenResponse.getAccessToken();
+    Date expirationTime = accessTokenResponse.getExpirationTime();
+    return new AccessToken(accessToken, expirationTime);
   }
   
   @Override

--- a/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
+++ b/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assert.assertNotSame;
 
 import com.google.auth.Credentials;
+import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 
 import org.junit.Test;
@@ -49,6 +50,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -74,6 +76,19 @@ public class AppEngineCredentialsTest {
 
     assertEquals(1, appIdentity.getGetAccessTokenCallCount());
     assertContainsBearerToken(metadata, expectedAccessToken);
+  }
+
+  @Test
+  public void refreshAccessToken_sameAs() throws IOException {
+    final String expectedAccessToken = "ExpectedAccessToken";
+
+    MockAppIdentityService appIdentity = new MockAppIdentityService();
+    appIdentity.setAccessTokenText(expectedAccessToken);
+    appIdentity.setExpiration(new Date(System.currentTimeMillis() + 60L * 60L * 100L));
+    AppEngineCredentials credentials = new AppEngineCredentials(SCOPES, appIdentity);
+    AccessToken accessToken = credentials.refreshAccessToken();
+    assertEquals(appIdentity.getAccessTokenText(), accessToken.getTokenValue());
+    assertEquals(appIdentity.getExpiration(), accessToken.getExpirationTime());
   }
 
   @Test  

--- a/appengine/javatests/com/google/auth/appengine/MockAppIdentityService.java
+++ b/appengine/javatests/com/google/auth/appengine/MockAppIdentityService.java
@@ -36,6 +36,7 @@ import com.google.appengine.api.appidentity.AppIdentityServiceFailureException;
 import com.google.appengine.api.appidentity.PublicCertificate;
 
 import java.util.Collection;
+import java.util.Date;
 
 /**
  * Mock implementation of AppIdentityService interface for testing.
@@ -44,6 +45,7 @@ public class MockAppIdentityService implements AppIdentityService {
 
   private int getAccessTokenCallCount = 0;
   private String accessTokenText = null;
+  private Date expiration = null;
 
   public MockAppIdentityService() {
   }
@@ -58,6 +60,14 @@ public class MockAppIdentityService implements AppIdentityService {
 
   public void setAccessTokenText(String text) {
     accessTokenText = text;
+  }
+
+  public Date getExpiration() {
+    return expiration;
+  }
+
+  public void setExpiration(Date expiration) {
+    this.expiration = expiration;
   }
 
   @Override
@@ -82,7 +92,7 @@ public class MockAppIdentityService implements AppIdentityService {
     if (scopeCount == 0) {
       throw new AppIdentityServiceFailureException("No scopes specified.");
     }
-    return new GetAccessTokenResult(accessTokenText, null);
+    return new GetAccessTokenResult(accessTokenText, expiration);
   }
 
   @Override


### PR DESCRIPTION
The expiration information is passed in by the AppIdentityService. Pass along the expiration time for the App Engine Flexible Environment.  Not having this causes problems such as https://github.com/GoogleCloudPlatform/cloud-bigtable-client/issues/750 and https://github.com/GoogleCloudPlatform/cloud-bigtable-examples/issues/145.