### PR TITLE
Implement the async method in oauth2 creds and JWT creds.

### DIFF
--- a/credentials/java/com/google/auth/Credentials.java
+++ b/credentials/java/com/google/auth/Credentials.java
@@ -55,20 +55,27 @@ public abstract class Credentials {
     executor.execute(new Runnable() {
         @Override
         public void run() {
-          Map<String, List<String>> result;
-          try {
-            result = getRequestMetadata(uri);
-          } catch (Throwable e) {
-            callback.onFailure(e);
-            return;
-          }
-          callback.onSuccess(result);
+          blockingGetToCallback(uri, callback);
         }
       });
   }
 
   /**
-   * Get the current request metadata, refreshing tokens if required.
+   * Call {@link #getRequestMetadata(URI)} and pass the result or error to the callback.
+   */
+  protected final void blockingGetToCallback(URI uri, RequestMetadataCallback callback) {
+    Map<String, List<String>> result;
+    try {
+      result = getRequestMetadata(uri);
+    } catch (Throwable e) {
+      callback.onFailure(e);
+      return;
+    }
+    callback.onSuccess(result);
+  }
+
+  /**
+   * Get the current request metadata in a blocking manner, refreshing tokens if required.
    *
    * <p>This should be called by the transport layer on each request, and the data should be
    * populated in headers or other context. The operation can block and fail to complete and may do

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -180,16 +180,9 @@ public class ServiceAccountJwtAccessCredentials extends Credentials {
   @Override
   public void getRequestMetadata(final URI uri, Executor executor,
       final RequestMetadataCallback callback) {
-    Map<String, List<String>> metadata;
-    try {
-      // It doesn't use network. Only some CPU work on par with TLS handshake. So it's preferrable
-      // to do it in the current thread, which is likely to be the network thread.
-      metadata = getRequestMetadata(uri);
-    } catch (Throwable e) {
-      callback.onFailure(e);
-      return;
-    }
-    callback.onSuccess(metadata);
+    // It doesn't use network. Only some CPU work on par with TLS handshake. So it's preferrable
+    // to do it in the current thread, which is likely to be the network thread.
+    blockingGetToCallback(uri, callback);
   }
 
   /**

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockExecutor.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockExecutor.java
@@ -1,0 +1,40 @@
+package com.google.auth.oauth2;
+
+import java.util.LinkedList;
+import java.util.concurrent.Executor;
+
+/**
+ * Mock thread-less executor.
+ */
+public final class MockExecutor implements Executor {
+  private LinkedList<Runnable> tasks = new LinkedList<Runnable>();
+
+  @Override
+  public void execute(Runnable task) {
+    tasks.add(task);
+  }
+
+  int runTasks() {
+    LinkedList<Runnable> savedTasks = tasks;
+    tasks = new LinkedList<Runnable>();
+    for (Runnable task : savedTasks) {
+      task.run();
+    }
+    return savedTasks.size();
+  }
+
+  int runTasksExhaustively() {
+    int num = 0;
+    while (true) {
+      int thisNum = runTasks();
+      if (thisNum == 0) {
+        return num;
+      }
+      num += thisNum;
+    }
+  }
+
+  int numTasks() {
+    return tasks.size();
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockExecutor.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockExecutor.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package com.google.auth.oauth2;
 
 import java.util.LinkedList;

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockRequestMetadataCallback.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockRequestMetadataCallback.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package com.google.auth.oauth2;
 
 import com.google.auth.RequestMetadataCallback;

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockRequestMetadataCallback.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockRequestMetadataCallback.java
@@ -1,0 +1,43 @@
+package com.google.auth.oauth2;
+
+import com.google.auth.RequestMetadataCallback;
+import com.google.common.base.Preconditions;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mock RequestMetadataCallback
+ */
+public final class MockRequestMetadataCallback implements RequestMetadataCallback {
+  Map<String, List<String>> metadata;
+  Throwable exception;
+
+  /**
+   * Called when metadata is successfully produced.
+   */
+  @Override
+  public void onSuccess(Map<String, List<String>> metadata) {
+    checkNotSet();
+    this.metadata = metadata;
+  }
+
+  /**
+   * Called when metadata generation failed.
+   */
+  @Override
+  public void onFailure(Throwable exception) {
+    checkNotSet();
+    this.exception = exception;
+  }
+
+  public void reset() {
+    this.metadata = null;
+    this.exception = null;
+  }
+
+  private void checkNotSet() {
+    Preconditions.checkState(this.metadata == null);
+    Preconditions.checkState(this.exception == null);
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -25,11 +25,13 @@ public class MockTokenServerTransport extends MockHttpTransport {
 
   static final String EXPECTED_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
   static final JsonFactory JSON_FACTORY = new JacksonFactory();
-  Map<String, String> clients = new HashMap<String, String>();
-  Map<String, String> refreshTokens = new HashMap<String, String>();
-  Map<String, String> serviceAccounts = new HashMap<String, String>();
-  Map<String, String> codes = new HashMap<String, String>();
+  int buildRequestCount;
+  final Map<String, String> clients = new HashMap<String, String>();
+  final Map<String, String> refreshTokens = new HashMap<String, String>();
+  final Map<String, String> serviceAccounts = new HashMap<String, String>();
+  final Map<String, String> codes = new HashMap<String, String>();
   URI tokenServerUri = OAuth2Utils.TOKEN_SERVER_URI;
+  private IOException error;
 
   public MockTokenServerTransport()  {
   }
@@ -63,8 +65,16 @@ public class MockTokenServerTransport extends MockHttpTransport {
     return refreshTokens.get(refreshToken);
   }
 
+  public void setError(IOException error) {
+    this.error = error;
+  }
+
   @Override
   public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+    buildRequestCount++;
+    if (error != null) {
+      throw error;
+    }
     int questionMarkPos = url.indexOf('?');
     final String urlWithoutQUery = (questionMarkPos > 0) ? url.substring(0, questionMarkPos) : url;
     final String query = (questionMarkPos > 0) ? url.substring(questionMarkPos + 1) : "";

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -148,7 +148,7 @@ public class ServiceAccountJwtAccessCredentialsTest {
   }
 
   @Test
-  public void getRequestMetadata_hasJwtAccess() throws IOException {
+  public void getRequestMetadata_blocking_hasJwtAccess() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     Credentials credentials = new ServiceAccountJwtAccessCredentials(
         SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID);
@@ -159,7 +159,7 @@ public class ServiceAccountJwtAccessCredentialsTest {
   }
 
   @Test
-  public void getRequestMetadata_defaultURI_hasJwtAccess() throws IOException {
+  public void getRequestMetadata_blocking_defaultURI_hasJwtAccess() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     Credentials credentials = new ServiceAccountJwtAccessCredentials(
         SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
@@ -170,7 +170,7 @@ public class ServiceAccountJwtAccessCredentialsTest {
   }
 
   @Test
-  public void getRequestMetadata_noURI_throws() throws IOException {
+  public void getRequestMetadata_blocking_noURI_throws() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     Credentials credentials = new ServiceAccountJwtAccessCredentials(
         SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID);
@@ -180,6 +180,47 @@ public class ServiceAccountJwtAccessCredentialsTest {
       fail("exception expected");
     } catch (IOException e) {
     }
+  }
+
+  @Test
+  public void getRequestMetadata_async_hasJwtAccess() throws IOException {
+    PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
+    Credentials credentials = new ServiceAccountJwtAccessCredentials(
+        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID);
+    MockExecutor executor = new MockExecutor();
+    MockRequestMetadataCallback callback = new MockRequestMetadataCallback();
+
+    credentials.getRequestMetadata(CALL_URI, executor, callback);
+    assertEquals(0, executor.numTasks());
+    assertNotNull(callback.metadata);
+    verifyJwtAccess(callback.metadata, SA_CLIENT_EMAIL, CALL_URI, SA_PRIVATE_KEY_ID);
+  }
+
+  @Test
+  public void getRequestMetadata_async_defaultURI_hasJwtAccess() throws IOException {
+    PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
+    Credentials credentials = new ServiceAccountJwtAccessCredentials(
+        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
+    MockExecutor executor = new MockExecutor();
+    MockRequestMetadataCallback callback = new MockRequestMetadataCallback();
+
+    credentials.getRequestMetadata(null, executor, callback);
+    assertEquals(0, executor.numTasks());
+    assertNotNull(callback.metadata);
+    verifyJwtAccess(callback.metadata, SA_CLIENT_EMAIL, CALL_URI, SA_PRIVATE_KEY_ID);
+  }
+
+  @Test
+  public void getRequestMetadata_async_noURI_exception() throws IOException {
+    PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
+    Credentials credentials = new ServiceAccountJwtAccessCredentials(
+        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID);
+    MockExecutor executor = new MockExecutor();
+    MockRequestMetadataCallback callback = new MockRequestMetadataCallback();
+
+    credentials.getRequestMetadata(null, executor, callback);
+    assertEquals(0, executor.numTasks());
+    assertNotNull(callback.exception);
   }
 
   private void verifyJwtAccess(Map<String, List<String>> metadata, String expectedEmail,


### PR DESCRIPTION
The OAuth2 creds will call the callback in network thread if cache is used. Otherwise, will do the blocking IO in the provided executor.

The JWT creds always calls the callback in network thread because it's only local CPU work.