### PR TITLE
Modify DefaultCredentialsProvider to use reflection to access AE SDK

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/AppEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AppEngineCredentials.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * OAuth2 credentials representing the built-in service account for Google App Engine.
+ *
+ * <p>Instances of this class use reflection to access AppIdentityService in AppEngine SDK.
+ */
+class AppEngineCredentials extends GoogleCredentials {
+
+  private static final long serialVersionUID = -493219027336622194L;
+
+  static final String APP_IDENTITY_SERVICE_FACTORY_CLASS =
+      "com.google.appengine.api.appidentity.AppIdentityServiceFactory";
+  static final String APP_IDENTITY_SERVICE_CLASS =
+      "com.google.appengine.api.appidentity.AppIdentityService";
+  static final String GET_ACCESS_TOKEN_RESULT_CLASS =
+      "com.google.appengine.api.appidentity.AppIdentityService$GetAccessTokenResult";
+  private static final String GET_APP_IDENTITY_SERVICE_METHOD = "getAppIdentityService";
+  private static final String GET_ACCESS_TOKEN_RESULT_METHOD = "getAccessToken";
+  private static final String GET_ACCESS_TOKEN_METHOD = "getAccessToken";
+  private static final String GET_EXPIRATION_TIME_METHOD = "getExpirationTime";
+
+  private final Collection<String> scopes;
+  private final boolean scopesRequired;
+
+  private transient Object appIdentityService;
+  private transient Method getAccessToken;
+  private transient Method getAccessTokenResult;
+  private transient Method getExpirationTime;
+
+  AppEngineCredentials(Collection<String> scopes) throws IOException {
+    this.scopes = scopes == null ? ImmutableSet.<String>of() : ImmutableList.copyOf(scopes);
+    this.scopesRequired = this.scopes.isEmpty();
+    init();
+  }
+
+  AppEngineCredentials(Collection<String> scopes, AppEngineCredentials unscoped) {
+    this.appIdentityService = unscoped.appIdentityService;
+    this.getAccessToken = unscoped.getAccessToken;
+    this.getAccessTokenResult = unscoped.getAccessTokenResult;
+    this.getExpirationTime = unscoped.getExpirationTime;
+    this.scopes = scopes == null ? ImmutableSet.<String>of() : ImmutableList.copyOf(scopes);
+    this.scopesRequired = this.scopes.isEmpty();
+  }
+
+  private void init() throws IOException {
+    try {
+      Class<?> factoryClass = forName(APP_IDENTITY_SERVICE_FACTORY_CLASS);
+      Method method = factoryClass.getMethod(GET_APP_IDENTITY_SERVICE_METHOD);
+      this.appIdentityService = method.invoke(null);
+      Class<?> serviceClass = forName(APP_IDENTITY_SERVICE_CLASS);
+      Class<?> tokenResultClass = forName(GET_ACCESS_TOKEN_RESULT_CLASS);
+      this.getAccessTokenResult =
+          serviceClass.getMethod(GET_ACCESS_TOKEN_RESULT_METHOD, Iterable.class);
+      this.getAccessToken = tokenResultClass.getMethod(GET_ACCESS_TOKEN_METHOD);
+      this.getExpirationTime = tokenResultClass.getMethod(GET_EXPIRATION_TIME_METHOD);
+    } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
+        | InvocationTargetException ex) {
+      throw new IOException(
+          "Application Default Credentials failed to create the Google App Engine service account"
+              + " credentials. Check that the App Engine SDK is deployed.", ex);
+    }
+  }
+
+  /**
+   * Refresh the access token by getting it from the App Identity service.
+   */
+  @Override
+  public AccessToken refreshAccessToken() throws IOException {
+    if (createScopedRequired()) {
+      throw new IOException("AppEngineCredentials requires createScoped call before use.");
+    }
+    try {
+      Object accessTokenResult = getAccessTokenResult.invoke(appIdentityService, scopes);
+      String accessToken = (String) getAccessToken.invoke(accessTokenResult);
+      Date expirationTime = (Date) getExpirationTime.invoke(accessTokenResult);
+      return new AccessToken(accessToken, expirationTime);
+    } catch (Exception e) {
+      throw new IOException("Could not get the access token.", e);
+    }
+  }
+
+  @Override
+  public boolean createScopedRequired() {
+    return scopesRequired;
+  }
+
+  @Override
+  public GoogleCredentials createScoped(Collection<String> scopes) {
+    return new AppEngineCredentials(scopes, this);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(scopes, scopesRequired);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("scopes", scopes)
+        .add("scopesRequired", scopesRequired)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof AppEngineCredentials)) {
+      return false;
+    }
+    AppEngineCredentials other = (AppEngineCredentials) obj;
+    return this.scopesRequired == other.scopesRequired
+        && Objects.equals(this.scopes, other.scopes);
+  }
+
+  private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
+    input.defaultReadObject();
+    init();
+  }
+
+  /*
+   * Start of methods to allow overriding in the test code to isolate from the environment.
+   */
+
+  Class<?> forName(String className) throws ClassNotFoundException {
+    return Class.forName(className);
+  }
+
+  /*
+   * End of methods to allow overriding in the test code to isolate from the environment.
+   */
+}

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -64,9 +64,6 @@ class DefaultCredentialsProvider {
   static final String HELP_PERMALINK =
       "https://developers.google.com/accounts/docs/application-default-credentials";
 
-  static final String APP_ENGINE_CREDENTIAL_CLASS =
-      "com.google.auth.appengine.AppEngineCredentials";
-
   static final String APP_ENGINE_SIGNAL_CLASS = "com.google.appengine.api.utils.SystemProperty";
 
   static final String CLOUD_SHELL_ENV_VAR = "DEVSHELL_CLIENT_PORT";
@@ -245,22 +242,7 @@ class DefaultCredentialsProvider {
     if (!onAppEngine) {
       return null;
     }
-    Exception innerException;
-    try {
-      Class<?> credentialClass = forName(APP_ENGINE_CREDENTIAL_CLASS);
-      Constructor<?> constructor = credentialClass
-          .getConstructor(Collection.class);
-      Collection<String> emptyScopes = Collections.emptyList();
-      return (GoogleCredentials) constructor.newInstance(emptyScopes);
-    } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException
-        | IllegalAccessException | InvocationTargetException e) {
-      innerException = e;
-    }
-    throw new IOException(String.format(
-        "Application Default Credentials failed to create the Google App Engine service account"
-            + " credentials class %s. Check that the component 'google-auth-library-appengine' is"
-            + " deployed.",
-        APP_ENGINE_CREDENTIAL_CLASS), innerException);
+    return new AppEngineCredentials(Collections.<String>emptyList());
   }
 
   private final GoogleCredentials tryGetComputeCredentials(HttpTransportFactory transportFactory) {

--- a/oauth2_http/javatests/com/google/auth/oauth2/AppEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AppEngineCredentialsTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+public class AppEngineCredentialsTest extends BaseSerializationTest {
+
+  private static final String EXPECTED_ACCESS_TOKEN = "ExpectedAccessToken";
+  private static final Date EXPECTED_EXPIRATION_DATE =
+      new Date(System.currentTimeMillis() + 60L * 60L * 100L);
+
+  private static final Collection<String> SCOPES =
+      Collections.unmodifiableCollection(Arrays.asList("scope1", "scope2"));
+
+  @Test
+  public void constructor_usesAppIdentityService() throws IOException {
+    Collection<String> scopes = Collections.singleton("SomeScope");
+    TestAppEngineCredentials credentials = new TestAppEngineCredentials(scopes);
+    List<String> forNameArgs = credentials.getForNameArgs();
+    assertEquals(3, forNameArgs.size());
+    assertEquals(AppEngineCredentials.APP_IDENTITY_SERVICE_FACTORY_CLASS, forNameArgs.get(0));
+    assertEquals(AppEngineCredentials.APP_IDENTITY_SERVICE_CLASS, forNameArgs.get(1));
+    assertEquals(AppEngineCredentials.GET_ACCESS_TOKEN_RESULT_CLASS, forNameArgs.get(2));
+  }
+
+  @Test
+  public void constructor_noAppEngineRuntime_throwsHelpfulLoadError() throws IOException {
+    try {
+      new TestAppEngineCredentialsNoSdk();
+      fail("Credential expected to fail to load if credential class not present.");
+    } catch (IOException e) {
+      String message = e.getMessage();
+      assertTrue(message.contains("Check that the App Engine SDK is deployed."));
+      assertTrue(e.getCause() instanceof ClassNotFoundException);
+      assertTrue(e.getCause().getMessage().contains(
+          AppEngineCredentials.APP_IDENTITY_SERVICE_FACTORY_CLASS));
+    }
+  }
+
+  @Test
+  public void refreshAccessToken_sameAs() throws IOException {
+    TestAppEngineCredentials credentials = new TestAppEngineCredentials(SCOPES);
+    AccessToken accessToken = credentials.refreshAccessToken();
+    assertEquals(EXPECTED_ACCESS_TOKEN, accessToken.getTokenValue());
+    assertEquals(EXPECTED_EXPIRATION_DATE, accessToken.getExpirationTime());
+  }
+
+  @Test
+  public void createScoped_clonesWithScopes() throws IOException {
+    TestAppEngineCredentials credentials = new TestAppEngineCredentials(null);
+    assertTrue(credentials.createScopedRequired());
+    try {
+      credentials.refreshAccessToken();
+      fail("Should not be able to use credential without scopes.");
+    } catch (Exception expected) {
+      // Expected
+    }
+
+    GoogleCredentials scopedCredentials = credentials.createScoped(SCOPES);
+    assertNotSame(credentials, scopedCredentials);
+
+    AccessToken accessToken = scopedCredentials.refreshAccessToken();
+    assertEquals(EXPECTED_ACCESS_TOKEN, accessToken.getTokenValue());
+    assertEquals(EXPECTED_EXPIRATION_DATE, accessToken.getExpirationTime());
+  }
+
+  @Test
+  public void equals_true() throws IOException {
+    GoogleCredentials credentials = new TestAppEngineCredentials(SCOPES);
+    GoogleCredentials otherCredentials = new TestAppEngineCredentials(SCOPES);
+    assertTrue(credentials.equals(credentials));
+    assertTrue(credentials.equals(otherCredentials));
+    assertTrue(otherCredentials.equals(credentials));
+  }
+
+  @Test
+  public void equals_false_scopes() throws IOException {
+    final Collection<String> emptyScopes = Collections.emptyList();
+    Collection<String> scopes = Collections.singleton("SomeScope");
+    AppEngineCredentials credentials = new TestAppEngineCredentials(emptyScopes);
+    AppEngineCredentials otherCredentials = new TestAppEngineCredentials(scopes);
+    assertFalse(credentials.equals(otherCredentials));
+    assertFalse(otherCredentials.equals(credentials));
+  }
+
+  @Test
+  public void toString_containsFields() throws IOException {
+    String expectedToString = String.format(
+        "TestAppEngineCredentials{scopes=[%s], scopesRequired=%b}", "SomeScope", false);
+    Collection<String> scopes = Collections.singleton("SomeScope");
+    AppEngineCredentials credentials = new TestAppEngineCredentials(scopes);
+    assertEquals(expectedToString, credentials.toString());
+  }
+
+  @Test
+  public void hashCode_equals() throws IOException {
+    AppEngineCredentials credentials = new TestAppEngineCredentials(SCOPES);
+    assertEquals(credentials.hashCode(), credentials.hashCode());
+  }
+
+  @Test
+  public void serialize() throws IOException, ClassNotFoundException {
+    Collection<String> scopes = Collections.singleton("SomeScope");
+    AppEngineCredentials credentials = new TestAppEngineCredentials(scopes);
+    GoogleCredentials deserializedCredentials = serializeAndDeserialize(credentials);
+    assertEquals(credentials, deserializedCredentials);
+    assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());
+    assertEquals(credentials.toString(), deserializedCredentials.toString());
+  }
+
+  private static class TestAppIdentityServiceFactory {
+
+    public static TestAppIdentityService getAppIdentityService() {
+      return new TestAppIdentityService();
+    }
+  }
+
+  private static class TestAppIdentityService {
+
+    public TestGetAccessTokenResult getAccessToken(Iterable<String> scopes) {
+      return new TestGetAccessTokenResult(EXPECTED_ACCESS_TOKEN, EXPECTED_EXPIRATION_DATE);
+    }
+  }
+
+  private static class TestGetAccessTokenResult {
+
+    private final String accessToken;
+    private final Date expirationTime;
+
+    TestGetAccessTokenResult(String accessToken, Date expirationTime) {
+      this.accessToken = accessToken;
+      this.expirationTime = expirationTime;
+    }
+
+    public String getAccessToken() {
+      return this.accessToken;
+    }
+
+    public Date getExpirationTime() {
+      return this.expirationTime;
+    }
+  }
+
+  private static class TestAppEngineCredentials extends AppEngineCredentials {
+
+    private static final long serialVersionUID = -5191475572296306231L;
+
+    private static final Map<String, Class<?>> TYPES = ImmutableMap.of(
+        AppEngineCredentials.APP_IDENTITY_SERVICE_FACTORY_CLASS,
+        TestAppIdentityServiceFactory.class,
+        AppEngineCredentials.APP_IDENTITY_SERVICE_CLASS,
+        TestAppIdentityService.class,
+        AppEngineCredentials.GET_ACCESS_TOKEN_RESULT_CLASS,
+        TestGetAccessTokenResult.class);
+    private List<String> forNameArgs;
+
+    TestAppEngineCredentials(Collection<String> scopes) throws IOException {
+      super(scopes);
+    }
+
+    @Override
+    Class<?> forName(String className) throws ClassNotFoundException {
+      if (forNameArgs == null) {
+        forNameArgs = new ArrayList<>();
+      }
+      forNameArgs.add(className);
+      Class<?> lookup = TYPES.get(className);
+      if (lookup != null) {
+        return lookup;
+      }
+      throw new ClassNotFoundException(className);
+    }
+
+    List<String> getForNameArgs() {
+      return forNameArgs;
+    }
+  }
+
+  private static class TestAppEngineCredentialsNoSdk extends AppEngineCredentials {
+
+    private static final long serialVersionUID = -8987103249265111274L;
+
+    TestAppEngineCredentialsNoSdk() throws IOException {
+      super(null);
+    }
+
+    @Override
+    Class<?> forName(String className) throws ClassNotFoundException {
+      throw new ClassNotFoundException(className);
+    }
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -135,7 +135,7 @@ public class DefaultCredentialsProviderTest {
     String userPath = "/user.json";
     testProvider.addFile(userPath, userStream);
     testProvider.setEnv(DefaultCredentialsProvider.CREDENTIAL_ENV_VAR, userPath);
-    
+
     try {
       testProvider.getDefaultCredentials(transportFactory);
       fail("No credential expected.");
@@ -144,7 +144,7 @@ public class DefaultCredentialsProviderTest {
       assertTrue(message.contains(DefaultCredentialsProvider.HELP_PERMALINK));
     }
   }
-  
+
   @Test
   public void getDefaultCredentials_noCredentials_singleGceTestRequest() {
     MockRequestCountingTransportFactory transportFactory =
@@ -180,26 +180,9 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_appEngine_deployed() throws IOException  {
-    MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
-    TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
-    testProvider.addType(DefaultCredentialsProvider.APP_ENGINE_CREDENTIAL_CLASS,
-        MockAppEngineCredentials.class);
-    testProvider.addType(DefaultCredentialsProvider.APP_ENGINE_SIGNAL_CLASS,
-        MockAppEngineSystemProperty.class);
-
-    GoogleCredentials defaultCredential = testProvider.getDefaultCredentials(transportFactory);
-
-    assertNotNull(defaultCredential);
-    assertTrue(defaultCredential instanceof MockAppEngineCredentials);
-  }
-
-  @Test
   public void getDefaultCredentials_appEngineClassWithoutRuntime_NotFoundError() {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
-    testProvider.addType(DefaultCredentialsProvider.APP_ENGINE_CREDENTIAL_CLASS,
-        MockAppEngineCredentials.class);
     testProvider.addType(DefaultCredentialsProvider.APP_ENGINE_SIGNAL_CLASS,
         MockOffAppEngineSystemProperty.class);
 
@@ -225,29 +208,8 @@ public class DefaultCredentialsProviderTest {
     } catch (IOException e) {
       String message = e.getMessage();
       assertFalse(message.contains(DefaultCredentialsProvider.HELP_PERMALINK));
-      assertTrue(message.contains(DefaultCredentialsProvider.APP_ENGINE_CREDENTIAL_CLASS));
+      assertTrue(message.contains("Check that the App Engine SDK is deployed."));
     }
-  }
-
-  @Test
-  public void getDefaultCredentials_appEngine_singleClassLoadAttempt() {
-    MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
-    TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
-    try {
-      testProvider.getDefaultCredentials(transportFactory);
-      fail("No credential expected for default test provider.");
-    } catch (IOException expected) {
-      // Expected
-    }
-    assertEquals(1, testProvider.getForNameCallCount());
-    // Try a second time.
-    try {
-      testProvider.getDefaultCredentials(transportFactory);
-      fail("No credential expected for default test provider.");
-    } catch (IOException expected) {
-      // Expected
-    }
-    assertEquals(1, testProvider.getForNameCallCount());
   }
 
   @Test
@@ -268,7 +230,7 @@ public class DefaultCredentialsProviderTest {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.setEnv(DefaultCredentialsProvider.CLOUD_SHELL_ENV_VAR, "4");
-    
+
     GoogleCredentials defaultCredentials = testProvider.getDefaultCredentials(transportFactory);
 
     assertTrue(defaultCredentials instanceof CloudShellCredentials);
@@ -590,7 +552,7 @@ public class DefaultCredentialsProviderTest {
       }
       return stream;
     }
-        
+
     void setFileSandbox(boolean fileSandbox) {
       this.fileSandbox = fileSandbox;
     }


### PR DESCRIPTION
This PR does the following:
- Remove `OAuth2Utils.exceptionWithCause`, use exception costructor instead
- Add package-private `AppEngineCredentials` to `google-auth-library-oauth2-http` that uses reflection to access AE SDK
- Modify `DefaultCredentialsProvider` to instantiate the new `AppEngineCredentials` class

/cc @garrettjonesgoogle @anthmgoogle