### PR TITLE
Add signing capabilities to AppEngine and service account classes

### DIFF
--- a/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
+++ b/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
@@ -34,6 +34,7 @@ package com.google.auth.appengine;
 import com.google.appengine.api.appidentity.AppIdentityService;
 import com.google.appengine.api.appidentity.AppIdentityService.GetAccessTokenResult;
 import com.google.appengine.api.appidentity.AppIdentityServiceFactory;
+import com.google.auth.ServiceAccountSigner;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.MoreObjects;
@@ -51,7 +52,7 @@ import java.util.Objects;
  *
  * <p>Fetches access tokens from the App Identity service.
  */
-public class AppEngineCredentials extends GoogleCredentials {
+public class AppEngineCredentials extends GoogleCredentials implements ServiceAccountSigner {
 
   private static final long serialVersionUID = -2627708355455064660L;
 
@@ -95,6 +96,16 @@ public class AppEngineCredentials extends GoogleCredentials {
   @Override
   public GoogleCredentials createScoped(Collection<String> scopes) {
     return new AppEngineCredentials(scopes, appIdentityService);
+  }
+
+  @Override
+  public String getAccount() {
+    return appIdentityService.getServiceAccountName();
+  }
+
+  @Override
+  public byte[] sign(byte[] toSign) {
+    return appIdentityService.signForApp(toSign).getSignature();
   }
 
   @Override

--- a/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
+++ b/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
@@ -31,6 +31,7 @@
 
 package com.google.auth.appengine;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -65,6 +66,7 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
   private static final Collection<String> SCOPES =
       Collections.unmodifiableCollection(Arrays.asList("scope1", "scope2"));
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
+  private static final String EXPECTED_ACCOUNT = "serviceAccount";
   
   @Test  
   public void constructor_usesAppIdentityService() throws IOException {
@@ -93,7 +95,24 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
     assertEquals(appIdentity.getExpiration(), accessToken.getExpirationTime());
   }
 
-  @Test  
+  @Test
+  public void getAccount_sameAs() throws IOException {
+    MockAppIdentityService appIdentity = new MockAppIdentityService();
+    appIdentity.setServiceAccountName(EXPECTED_ACCOUNT);
+    AppEngineCredentials credentials = new AppEngineCredentials(SCOPES, appIdentity);
+    assertEquals(EXPECTED_ACCOUNT, credentials.getAccount());
+  }
+
+  @Test
+  public void sign_sameAs() throws IOException {
+    byte[] expectedSignature = {0xD, 0xE, 0xA, 0xD};
+    MockAppIdentityService appIdentity = new MockAppIdentityService();
+    appIdentity.setSignature(expectedSignature);
+    AppEngineCredentials credentials = new AppEngineCredentials(SCOPES, appIdentity);
+    assertArrayEquals(expectedSignature, credentials.sign(expectedSignature));
+  }
+
+  @Test
   public void createScoped_clonesWithScopes() throws IOException {
     final String expectedAccessToken = "ExpectedAccessToken";
     final Collection<String> emptyScopes = Collections.emptyList();

--- a/appengine/javatests/com/google/auth/appengine/MockAppIdentityService.java
+++ b/appengine/javatests/com/google/auth/appengine/MockAppIdentityService.java
@@ -46,6 +46,8 @@ public class MockAppIdentityService implements AppIdentityService {
   private int getAccessTokenCallCount = 0;
   private String accessTokenText = null;
   private Date expiration = null;
+  private String serviceAccountName = null;
+  private SigningResult signingResult = null;
 
   public MockAppIdentityService() {
   }
@@ -72,7 +74,11 @@ public class MockAppIdentityService implements AppIdentityService {
 
   @Override
   public SigningResult signForApp(byte[] signBlob) {
-    return null;
+    return signingResult;
+  }
+
+  public void setSignature(byte[] signature) {
+    this.signingResult = new SigningResult("keyName", signature);
   }
 
   @Override
@@ -102,7 +108,11 @@ public class MockAppIdentityService implements AppIdentityService {
 
   @Override
   public String getServiceAccountName() {
-    return null;
+    return serviceAccountName;
+  }
+
+  public void setServiceAccountName(String serviceAccountName) {
+    this.serviceAccountName = serviceAccountName;
   }
 
   @Override

--- a/credentials/java/com/google/auth/ServiceAccountSigner.java
+++ b/credentials/java/com/google/auth/ServiceAccountSigner.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth;
+
+import java.util.Objects;
+
+/**
+ * Interface for a service account signer. A signer for a service account is capable of signing
+ * bytes using the private key associated with its service account.
+ */
+public interface ServiceAccountSigner {
+
+  class SigningException extends RuntimeException {
+
+    private static final long serialVersionUID = -6503954300538947223L;
+
+    public SigningException(String message, Exception cause) {
+      super(message, cause);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof SigningException)) {
+        return false;
+      }
+      SigningException other = (SigningException) obj;
+      return Objects.equals(getCause(), other.getCause())
+          && Objects.equals(getMessage(), other.getMessage());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getMessage(), getCause());
+    }
+  }
+
+  /**
+   * Returns the service account associated with the signer.
+   */
+  String getAccount();
+
+  /**
+   * Signs the provided bytes using the private key associated with the service account.
+   *
+   * @param toSign bytes to sign
+   * @return signed bytes
+   * @throws SigningException if the attempt to sign the provided bytes failed
+   */
+  byte[] sign(byte[] toSign);
+}

--- a/credentials/javatests/com/google/auth/SigningExceptionTest.java
+++ b/credentials/javatests/com/google/auth/SigningExceptionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.google.auth.ServiceAccountSigner.SigningException;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class SigningExceptionTest {
+
+  private static final String EXPECTED_MESSAGE = "message";
+  private static final RuntimeException EXPECTED_CAUSE = new RuntimeException();
+
+  @Test
+  public void constructor() {
+    SigningException signingException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
+    assertEquals(EXPECTED_MESSAGE, signingException.getMessage());
+    assertSame(EXPECTED_CAUSE, signingException.getCause());
+  }
+
+  @Test
+  public void equals_true() throws IOException {
+    SigningException signingException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
+    SigningException otherSigningException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
+    assertTrue(signingException.equals(otherSigningException));
+    assertTrue(otherSigningException.equals(signingException));
+  }
+
+  @Test
+  public void equals_false_message() throws IOException {
+    SigningException signingException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
+    SigningException otherSigningException = new SigningException("otherMessage", EXPECTED_CAUSE);
+    assertFalse(signingException.equals(otherSigningException));
+    assertFalse(otherSigningException.equals(signingException));
+  }
+
+  @Test
+  public void equals_false_cause() throws IOException {
+    SigningException signingException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
+    SigningException otherSigningException =
+        new SigningException("otherMessage", new RuntimeException());
+    assertFalse(signingException.equals(otherSigningException));
+    assertFalse(otherSigningException.equals(signingException));
+  }
+
+  @Test
+  public void hashCode_equals() throws IOException {
+    SigningException signingException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
+    SigningException otherSigningException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
+    assertEquals(signingException.hashCode(), otherSigningException.hashCode());
+  }
+}

--- a/credentials/pom.xml
+++ b/credentials/pom.xml
@@ -21,6 +21,7 @@
 
   <build>
     <sourceDirectory>java</sourceDirectory>
+    <testSourceDirectory>javatests</testSourceDirectory>
     <plugins>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
@@ -36,5 +37,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
@@ -49,8 +49,8 @@ import java.util.Objects;
 public class CloudShellCredentials extends GoogleCredentials {
 
   private static final long serialVersionUID = -2133257318957488451L;
-  private final static int ACCESS_TOKEN_INDEX = 2;
-  private final static int READ_TIMEOUT_MS = 5000;
+  private static final int ACCESS_TOKEN_INDEX = 2;
+  private static final int READ_TIMEOUT_MS = 5000;
 
   /**
    * The Cloud Shell back authorization channel uses serialized

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
@@ -55,6 +55,8 @@ import java.util.Map;
  * Internal utilities for the com.google.auth.oauth2 namespace.
  */
 class OAuth2Utils {
+  static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
+
   static final URI TOKEN_SERVER_URI = URI.create("https://accounts.google.com/o/oauth2/token");
   static final URI TOKEN_REVOKE_URI = URI.create("https://accounts.google.com/o/oauth2/revoke");
   static final URI USER_AUTH_URI = URI.create("https://accounts.google.com/o/oauth2/auth");

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -75,13 +75,13 @@ public class DefaultCredentialsProviderTest {
   private static final String USER_CLIENT_ID = "ya29.1.AADtN_UtlxN3PuGAxrN2XQnZTVRvDyVWnYq4I6dws";
   private static final String REFRESH_TOKEN = "1/Tl6awhpFjkMkSJoj1xsli0H2eL5YsMgU_NKPY2TyGWY";
   private static final String ACCESS_TOKEN = "1/MkSJoj1xsli0AccessToken_NKPY2";
-  private final static String SA_CLIENT_EMAIL =
+  private static final String SA_CLIENT_EMAIL =
       "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr@developer.gserviceaccount.com";
-  private final static String SA_CLIENT_ID =
+  private static final String SA_CLIENT_ID =
       "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr.apps.googleusercontent.com";
-  private final static String SA_PRIVATE_KEY_ID =
+  private static final String SA_PRIVATE_KEY_ID =
       "d84a4fefcf50791d4a90f2d7af17469d6282df9d";
-  private final static String SA_PRIVATE_KEY_PKCS8
+  private static final String SA_PRIVATE_KEY_PKCS8
       = ServiceAccountCredentialsTest.SA_PRIVATE_KEY_PKCS8;
   private static final Collection<String> SCOPES = Collections.singletonList("dummy.scope");
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -60,13 +60,13 @@ import java.util.Map;
 @RunWith(JUnit4.class)
 public class GoogleCredentialsTest {
 
-  private final static String SA_CLIENT_EMAIL =
+  private static final String SA_CLIENT_EMAIL =
       "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr@developer.gserviceaccount.com";
-  private final static String SA_CLIENT_ID =
+  private static final String SA_CLIENT_ID =
       "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr.apps.googleusercontent.com";
-  private final static String SA_PRIVATE_KEY_ID =
+  private static final String SA_PRIVATE_KEY_ID =
       "d84a4fefcf50791d4a90f2d7af17469d6282df9d";
-  private final static String SA_PRIVATE_KEY_PKCS8
+  private static final String SA_PRIVATE_KEY_PKCS8
       = ServiceAccountCredentialsTest.SA_PRIVATE_KEY_PKCS8;
   private static final String USER_CLIENT_SECRET = "jakuaL9YyieakhECKL2SwZcu";
   private static final String USER_CLIENT_ID = "ya29.1.AADtN_UtlxN3PuGAxrN2XQnZTVRvDyVWnYq4I6dws";

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -70,11 +70,11 @@ import java.util.Map;
 @RunWith(JUnit4.class)
 public class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
-  private final static String SA_CLIENT_EMAIL =
+  private static final String SA_CLIENT_EMAIL =
       "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr@developer.gserviceaccount.com";
-  private final static String SA_CLIENT_ID =
+  private static final String SA_CLIENT_ID =
       "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr.apps.googleusercontent.com";
-  private final static String SA_PRIVATE_KEY_ID =
+  private static final String SA_PRIVATE_KEY_ID =
       "d84a4fefcf50791d4a90f2d7af17469d6282df9d";
   static final String SA_PRIVATE_KEY_PKCS8 = "-----BEGIN PRIVATE KEY-----\n"
       + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALX0PQoe1igW12i"
@@ -89,8 +89,8 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
       + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
       + "==\n-----END PRIVATE KEY-----\n";
   private static final String ACCESS_TOKEN = "1/MkSJoj1xsli0AccessToken_NKPY2";
-  private final static Collection<String> SCOPES = Collections.singletonList("dummy.scope");
-  private final static Collection<String> EMPTY_SCOPES = Collections.emptyList();
+  private static final Collection<String> SCOPES = Collections.singletonList("dummy.scope");
+  private static final Collection<String> EMPTY_SCOPES = Collections.emptyList();
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -53,7 +53,11 @@ import org.junit.runners.JUnit4;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.SignatureException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -192,6 +196,26 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     assertNotNull(scopes);
     assertTrue(scopes.isEmpty());
+  }
+
+  @Test
+  public void getAccount_sameAs() throws IOException {
+    ServiceAccountCredentials credentials = ServiceAccountCredentials.fromPkcs8(
+        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null);
+    assertEquals(SA_CLIENT_EMAIL, credentials.getAccount());
+  }
+
+  @Test
+  public void sign_sameAs()
+      throws IOException, NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+    byte[] toSign = {0xD, 0xE, 0xA, 0xD};
+    ServiceAccountCredentials credentials = ServiceAccountCredentials.fromPkcs8(
+        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null);
+    byte[] signedBytes = credentials.sign(toSign);
+    Signature signature = Signature.getInstance(OAuth2Utils.SIGNATURE_ALGORITHM);
+    signature.initSign(credentials.getPrivateKey());
+    signature.update(toSign);
+    assertArrayEquals(signature.sign(), signedBytes);
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -67,11 +67,11 @@ import java.util.Map;
 @RunWith(JUnit4.class)
 public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTest {
 
-  private final static String SA_CLIENT_EMAIL =
+  private static final String SA_CLIENT_EMAIL =
       "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr@developer.gserviceaccount.com";
-  private final static String SA_CLIENT_ID =
+  private static final String SA_CLIENT_ID =
       "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr.apps.googleusercontent.com";
-  private final static String SA_PRIVATE_KEY_ID =
+  private static final String SA_PRIVATE_KEY_ID =
       "d84a4fefcf50791d4a90f2d7af17469d6282df9d";
   private static final String SA_PRIVATE_KEY_PKCS8 = "-----BEGIN PRIVATE KEY-----\n"
       + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALX0PQoe1igW12i"

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
@@ -68,7 +68,7 @@ public class UserCredentialsTest extends BaseSerializationTest {
   private static final String CLIENT_ID = "ya29.1.AADtN_UtlxN3PuGAxrN2XQnZTVRvDyVWnYq4I6dws";
   private static final String REFRESH_TOKEN = "1/Tl6awhpFjkMkSJoj1xsli0H2eL5YsMgU_NKPY2TyGWY";
   private static final String ACCESS_TOKEN = "1/MkSJoj1xsli0AccessToken_NKPY2";
-  private final static Collection<String> SCOPES = Collections.singletonList("dummy.scope");
+  private static final Collection<String> SCOPES = Collections.singletonList("dummy.scope");
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
 
   @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
This PR does the following:

- Add `ServiceAccountSigner` interface and related tests
- Add signing capabilities to `AppEngineCredentials` class in `appengine` package
- Add signing capabilities to service account and AE credentials in `oauth` package