### PR TITLE
Add better javadoc for Application Default Credentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -79,9 +79,9 @@ class DefaultCredentialsProvider {
   /**
    * Returns the Application Default Credentials.
    *
-   * <p>Returns the Application Default Credentials which are credentials that identify and
-   * authorize the whole application. Application Default Credentials are looked for in the
-   * following order:
+   * <p>Returns the Application Default Credentials which are used to identify and authorize the
+   * whole application. The following are searched (in order) to find the Application Default
+   * Credentials:
    * <ol>
    *   <li>Credentials file pointed to by the {@code GOOGLE_APPLICATION_CREDENTIALS} environment
    *   variable</li>

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -80,9 +80,16 @@ class DefaultCredentialsProvider {
    * Returns the Application Default Credentials.
    *
    * <p>Returns the Application Default Credentials which are credentials that identify and
-   * authorize the whole application. This is the built-in service account if running on Google
-   * Compute Engine or credentials specified by an environment variable or a file in a well-known
-   * location.</p>
+   * authorize the whole application. Application Default Credentials are looked for in the
+   * following order:
+   * <ol>
+   *   <li>Credentials file pointed to by the {@code GOOGLE_APPLICATION_CREDENTIALS} environment
+   *   variable</li>
+   *   <li>Google Cloud SDK ({@code gcloud}) credentials</li>
+   *   <li>Google App Engine built-in credentials</li>
+   *   <li>Google Cloud Shell built-in credentials</li>
+   *   <li>Google Compute Engine built-in credentials</li>
+   * </ol>
    *
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -85,8 +85,8 @@ class DefaultCredentialsProvider {
    * <ol>
    *   <li>Credentials file pointed to by the {@code GOOGLE_APPLICATION_CREDENTIALS} environment
    *   variable</li>
-   *   <li>Credentials provided by Cloud SDK {@code gcloud auth application-default login} command
-   *   </li>
+   *   <li>Credentials provided by the Google Cloud SDK
+   *   {@code gcloud auth application-default login} command</li>
    *   <li>Google App Engine built-in credentials</li>
    *   <li>Google Cloud Shell built-in credentials</li>
    *   <li>Google Compute Engine built-in credentials</li>

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -85,7 +85,8 @@ class DefaultCredentialsProvider {
    * <ol>
    *   <li>Credentials file pointed to by the {@code GOOGLE_APPLICATION_CREDENTIALS} environment
    *   variable</li>
-   *   <li>Google Cloud SDK ({@code gcloud}) credentials</li>
+   *   <li>Credentials provided by Cloud SDK {@code gcloud auth application-default login} command
+   *   </li>
    *   <li>Google App Engine built-in credentials</li>
    *   <li>Google Cloud Shell built-in credentials</li>
    *   <li>Google Compute Engine built-in credentials</li>

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -62,8 +62,8 @@ public class GoogleCredentials extends OAuth2Credentials {
    * <ol>
    *   <li>Credentials file pointed to by the {@code GOOGLE_APPLICATION_CREDENTIALS} environment
    *   variable</li>
-   *   <li>Credentials provided by Cloud SDK {@code gcloud auth application-default login} command
-   *   </li>
+   *   <li>Credentials provided by the Google Cloud SDK
+   *   {@code gcloud auth application-default login} command</li>
    *   <li>Google App Engine built-in credentials</li>
    *   <li>Google Cloud Shell built-in credentials</li>
    *   <li>Google Compute Engine built-in credentials</li>
@@ -85,8 +85,8 @@ public class GoogleCredentials extends OAuth2Credentials {
    * <ol>
    *   <li>Credentials file pointed to by the {@code GOOGLE_APPLICATION_CREDENTIALS} environment
    *   variable</li>
-   *   <li>Credentials provided by Cloud SDK {@code gcloud auth application-default login} command
-   *   </li>
+   *   <li>Credentials provided by the Google Cloud SDK
+   *   {@code gcloud auth application-default login} command</li>
    *   <li>Google App Engine built-in credentials</li>
    *   <li>Google Cloud Shell built-in credentials</li>
    *   <li>Google Compute Engine built-in credentials</li>

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -57,9 +57,16 @@ public class GoogleCredentials extends OAuth2Credentials {
    * Returns the Application Default Credentials.
    *
    * <p>Returns the Application Default Credentials which are credentials that identify and
-   * authorize the whole application. This is the built-in service account if running on Google
-   * Compute Engine or the credentials file from the path in the environment variable
-   * GOOGLE_APPLICATION_CREDENTIALS.</p>
+   * authorize the whole application. Application Default Credentials are looked for in the
+   * following order:
+   * <ol>
+   *   <li>Credentials file pointed to by the {@code GOOGLE_APPLICATION_CREDENTIALS} environment
+   *   variable</li>
+   *   <li>Google Cloud SDK ({@code gcloud}) credentials</li>
+   *   <li>Google App Engine built-in credentials</li>
+   *   <li>Google Cloud Shell built-in credentials</li>
+   *   <li>Google Compute Engine built-in credentials</li>
+   * </ol>
    *
    * @return the credentials instance.
    * @throws IOException if the credentials cannot be created in the current environment.
@@ -72,9 +79,16 @@ public class GoogleCredentials extends OAuth2Credentials {
    * Returns the Application Default Credentials.
    *
    * <p>Returns the Application Default Credentials which are credentials that identify and
-   * authorize the whole application. This is the built-in service account if running on Google
-   * Compute Engine or the credentials file from the path in the environment variable
-   * GOOGLE_APPLICATION_CREDENTIALS.</p>
+   * authorize the whole application. Application Default Credentials are looked for in the
+   * following order:
+   * <ol>
+   *   <li>Credentials file pointed to by the {@code GOOGLE_APPLICATION_CREDENTIALS} environment
+   *   variable</li>
+   *   <li>Google Cloud SDK ({@code gcloud}) credentials</li>
+   *   <li>Google App Engine built-in credentials</li>
+   *   <li>Google Cloud Shell built-in credentials</li>
+   *   <li>Google Compute Engine built-in credentials</li>
+   * </ol>
    *
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -62,7 +62,8 @@ public class GoogleCredentials extends OAuth2Credentials {
    * <ol>
    *   <li>Credentials file pointed to by the {@code GOOGLE_APPLICATION_CREDENTIALS} environment
    *   variable</li>
-   *   <li>Google Cloud SDK ({@code gcloud}) credentials</li>
+   *   <li>Credentials provided by Cloud SDK {@code gcloud auth application-default login} command
+   *   </li>
    *   <li>Google App Engine built-in credentials</li>
    *   <li>Google Cloud Shell built-in credentials</li>
    *   <li>Google Compute Engine built-in credentials</li>
@@ -84,7 +85,8 @@ public class GoogleCredentials extends OAuth2Credentials {
    * <ol>
    *   <li>Credentials file pointed to by the {@code GOOGLE_APPLICATION_CREDENTIALS} environment
    *   variable</li>
-   *   <li>Google Cloud SDK ({@code gcloud}) credentials</li>
+   *   <li>Credentials provided by Cloud SDK {@code gcloud auth application-default login} command
+   *   </li>
    *   <li>Google App Engine built-in credentials</li>
    *   <li>Google Cloud Shell built-in credentials</li>
    *   <li>Google Compute Engine built-in credentials</li>

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -56,9 +56,9 @@ public class GoogleCredentials extends OAuth2Credentials {
   /**
    * Returns the Application Default Credentials.
    *
-   * <p>Returns the Application Default Credentials which are credentials that identify and
-   * authorize the whole application. Application Default Credentials are looked for in the
-   * following order:
+   * <p>Returns the Application Default Credentials which are used to identify and authorize the
+   * whole application. The following are searched (in order) to find the Application Default
+   * Credentials:
    * <ol>
    *   <li>Credentials file pointed to by the {@code GOOGLE_APPLICATION_CREDENTIALS} environment
    *   variable</li>
@@ -78,9 +78,9 @@ public class GoogleCredentials extends OAuth2Credentials {
   /**
    * Returns the Application Default Credentials.
    *
-   * <p>Returns the Application Default Credentials which are credentials that identify and
-   * authorize the whole application. Application Default Credentials are looked for in the
-   * following order:
+   * <p>Returns the Application Default Credentials which are used to identify and authorize the
+   * whole application. The following are searched (in order) to find the Application Default
+   * Credentials:
    * <ol>
    *   <li>Credentials file pointed to by the {@code GOOGLE_APPLICATION_CREDENTIALS} environment
    *   variable</li>


### PR DESCRIPTION
This adds more detailed javadoc to:
- `DefaultCredentialsProvider.getDefaultCredentials()`
- `GoogleCredentials.getApplicationDefault(Transport)`
- `GoogleCredentials.getApplicationDefault(Transport)`

@lesv do you mind having a look at this?