### PR TITLE
Add fromStream to ServiceAccountCredentials and ServiceAccountJwtAccessCredentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -262,7 +262,7 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
       throw new IOException("Error reading credentials from stream, 'type' field not specified.");
     }
     if (SERVICE_ACCOUNT_FILE_TYPE.equals(fileType)) {
-      return ServiceAccountCredentials.fromJson(fileContents, transportFactory);
+      return fromJson(fileContents, transportFactory);
     }
     throw new IOException(String.format(
         "Error reading credentials from stream, 'type' value '%s' not recognized."

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -38,6 +38,7 @@ import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.UrlEncodedContent;
+import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.json.webtoken.JsonWebSignature;
@@ -54,6 +55,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.Reader;
 import java.io.StringReader;
@@ -220,6 +222,51 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
       unexpectedException = exception;
     }
     throw new IOException("Unexpected exception reading PKCS#8 data", unexpectedException);
+  }
+
+  /**
+   * Returns credentials defined by a Service Account key file in JSON format from the Google
+   * Developers Console.
+   *
+   * @param credentialsStream the stream with the credential definition.
+   * @return the credential defined by the credentialsStream.
+   * @throws IOException if the credential cannot be created from the stream.
+   **/
+  public static ServiceAccountCredentials fromStream(InputStream credentialsStream)
+      throws IOException {
+    return fromStream(credentialsStream, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
+  }
+
+  /**
+   * Returns credentials defined by a Service Account key file in JSON format from the Google
+   * Developers Console.
+   *
+   * @param credentialsStream the stream with the credential definition.
+   * @param transportFactory HTTP transport factory, creates the transport used to get access
+   *        tokens.
+   * @return the credential defined by the credentialsStream.
+   * @throws IOException if the credential cannot be created from the stream.
+   **/
+  public static ServiceAccountCredentials fromStream(InputStream credentialsStream,
+      HttpTransportFactory transportFactory) throws IOException {
+    Preconditions.checkNotNull(credentialsStream);
+    Preconditions.checkNotNull(transportFactory);
+
+    JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
+    JsonObjectParser parser = new JsonObjectParser(jsonFactory);
+    GenericJson fileContents = parser.parseAndClose(
+        credentialsStream, OAuth2Utils.UTF_8, GenericJson.class);
+
+    String fileType = (String) fileContents.get("type");
+    if (fileType == null) {
+      throw new IOException("Error reading credentials from stream, 'type' field not specified.");
+    }
+    if (SERVICE_ACCOUNT_FILE_TYPE.equals(fileType)) {
+      return ServiceAccountCredentials.fromJson(fileContents, transportFactory);
+    }
+    throw new IOException(String.format(
+        "Error reading credentials from stream, 'type' value '%s' not recognized."
+            + " Expecting '%s'.", fileType, SERVICE_ACCOUNT_FILE_TYPE));
   }
 
   /**

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -215,7 +215,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
       throw new IOException("Error reading credentials from stream, 'type' field not specified.");
     }
     if (SERVICE_ACCOUNT_FILE_TYPE.equals(fileType)) {
-      return ServiceAccountJwtAccessCredentials.fromJson(fileContents, defaultAudience);
+      return fromJson(fileContents, defaultAudience);
     }
     throw new IOException(String.format(
         "Error reading credentials from stream, 'type' value '%s' not recognized."

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -31,7 +31,11 @@
 
 package com.google.auth.oauth2;
 
+import static com.google.auth.oauth2.GoogleCredentials.SERVICE_ACCOUNT_FILE_TYPE;
+
+import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.api.client.util.Clock;
@@ -44,6 +48,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.net.URI;
 import java.security.GeneralSecurityException;
@@ -123,7 +128,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   }
 
   /**
-   * Returns service account crentials defined by JSON using the format supported by the Google
+   * Returns service account credentials defined by JSON using the format supported by the Google
    * Developers Console.
    *
    * @param json a map from the JSON representing the credentials.
@@ -172,6 +177,49 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(privateKeyPkcs8);
     return new ServiceAccountJwtAccessCredentials(
         clientId, clientEmail, privateKey, privateKeyId, defaultAudience);
+  }
+
+  /**
+   * Returns credentials defined by a Service Account key file in JSON format from the Google
+   * Developers Console.
+   *
+   * @param credentialsStream the stream with the credential definition.
+   * @return the credential defined by the credentialsStream.
+   * @throws IOException if the credential cannot be created from the stream.
+   **/
+  public static ServiceAccountJwtAccessCredentials fromStream(InputStream credentialsStream)
+      throws IOException {
+    return fromStream(credentialsStream, null);
+  }
+
+  /**
+   * Returns credentials defined by a Service Account key file in JSON format from the Google
+   * Developers Console.
+   *
+   * @param credentialsStream the stream with the credential definition.
+   * @param defaultAudience Audience to use if not provided by transport. May be null.
+   * @return the credential defined by the credentialsStream.
+   * @throws IOException if the credential cannot be created from the stream.
+   **/
+  public static ServiceAccountJwtAccessCredentials fromStream(InputStream credentialsStream,
+      URI defaultAudience) throws IOException {
+    Preconditions.checkNotNull(credentialsStream);
+
+    JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
+    JsonObjectParser parser = new JsonObjectParser(jsonFactory);
+    GenericJson fileContents = parser.parseAndClose(
+        credentialsStream, OAuth2Utils.UTF_8, GenericJson.class);
+
+    String fileType = (String) fileContents.get("type");
+    if (fileType == null) {
+      throw new IOException("Error reading credentials from stream, 'type' field not specified.");
+    }
+    if (SERVICE_ACCOUNT_FILE_TYPE.equals(fileType)) {
+      return ServiceAccountJwtAccessCredentials.fromJson(fileContents, defaultAudience);
+    }
+    throw new IOException(String.format(
+        "Error reading credentials from stream, 'type' value '%s' not recognized."
+            + " Expecting '%s'.", fileType, SERVICE_ACCOUNT_FILE_TYPE));
   }
 
   @Override

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -272,7 +272,7 @@ public class DefaultCredentialsProviderTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
+        .writeServiceAccountStream(
             SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     String serviceAccountPath = "/service_account.json";

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -222,7 +222,8 @@ public class GoogleCredentialsTest {
   private static void testFromStreamException(InputStream stream, String expectedMessageContent) {
     try {
       GoogleCredentials.fromStream(stream, DUMMY_TRANSPORT_FACTORY);
-      fail();
+      fail(String.format("Should throw exception with message containing '%s'",
+          expectedMessageContent));
     } catch (IOException expected) {
       assertTrue(expected.getMessage().contains(expectedMessageContent));
     }

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -219,7 +219,7 @@ public class GoogleCredentialsTest {
     testFromStreamException(userStream, "refresh_token");
   }
 
-  static void testFromStreamException(InputStream stream, String expectedMessageContent) {
+  private static void testFromStreamException(InputStream stream, String expectedMessageContent) {
     try {
       GoogleCredentials.fromStream(stream, DUMMY_TRANSPORT_FACTORY);
       fail();

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -223,7 +223,7 @@ public class GoogleCredentialsTest {
     testFromStreamException(userStream, "refresh_token");
   }
 
-  private void testFromStreamException(InputStream stream, String expectedMessageContent) {
+  static void testFromStreamException(InputStream stream, String expectedMessageContent) {
     try {
       GoogleCredentials.fromStream(stream, DUMMY_TRANSPORT_FACTORY);
       fail();

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -114,18 +114,18 @@ public class GoogleCredentialsTest {
     InputStream stream = new ByteArrayInputStream("foo".getBytes());
     try {
       GoogleCredentials.fromStream(stream, null);
-      fail();
+      fail("Should throw if HttpTransportFactory is null");
     } catch (NullPointerException expected) {
       // Expected
     }
   }
 
   @Test
-  public void fromStream_nullStreamThrows() throws IOException {
+  public void fromStream_nullStream_Throws() throws IOException {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     try {
       GoogleCredentials.fromStream(null, transportFactory);
-      fail();
+      fail("Should throw if InputStream is null");
     } catch (NullPointerException expected) {
       // Expected
     }
@@ -136,7 +136,7 @@ public class GoogleCredentialsTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
+        .writeServiceAccountStream(
             SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 
     GoogleCredentials credentials =
@@ -151,8 +151,7 @@ public class GoogleCredentialsTest {
   @Test
   public void fromStream_serviceAccountNoClientId_throws() throws IOException {
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            null, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+        .writeServiceAccountStream(null, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 
     testFromStreamException(serviceAccountStream, "client_id");
   }
@@ -160,8 +159,7 @@ public class GoogleCredentialsTest {
   @Test
   public void fromStream_serviceAccountNoClientEmail_throws() throws IOException {
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            SA_CLIENT_ID, null, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+        .writeServiceAccountStream(SA_CLIENT_ID, null, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 
     testFromStreamException(serviceAccountStream, "client_email");
   }
@@ -169,8 +167,7 @@ public class GoogleCredentialsTest {
   @Test
   public void fromStream_serviceAccountNoPrivateKey_throws() throws IOException {
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            SA_CLIENT_ID, SA_CLIENT_EMAIL, null, SA_PRIVATE_KEY_ID);
+        .writeServiceAccountStream(SA_CLIENT_ID, SA_CLIENT_EMAIL, null, SA_PRIVATE_KEY_ID);
 
     testFromStreamException(serviceAccountStream, "private_key");
   }
@@ -178,8 +175,7 @@ public class GoogleCredentialsTest {
   @Test
   public void fromStream_serviceAccountNoPrivateKeyId_throws() throws IOException {
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, null);
+        .writeServiceAccountStream(SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, null);
 
     testFromStreamException(serviceAccountStream, "private_key_id");
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -121,7 +121,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_nullStream_Throws() throws IOException {
+  public void fromStream_nullStream_throws() throws IOException {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     try {
       GoogleCredentials.fromStream(null, transportFactory);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -31,7 +31,6 @@
 
 package com.google.auth.oauth2;
 
-import static com.google.auth.oauth2.GoogleCredentialsTest.testFromStreamException;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -463,5 +462,14 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     GenericJson json =
         writeServiceAccountJson(clientId, clientEmail, privateKeyPkcs8, privateKeyId);
     return TestUtils.jsonToInputStream(json);
+  }
+
+  private static void testFromStreamException(InputStream stream, String expectedMessageContent) {
+    try {
+      ServiceAccountCredentials.fromStream(stream, DUMMY_TRANSPORT_FACTORY);
+      fail();
+    } catch (IOException expected) {
+      assertTrue(expected.getMessage().contains(expectedMessageContent));
+    }
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -374,18 +374,18 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     InputStream stream = new ByteArrayInputStream("foo".getBytes());
     try {
       ServiceAccountCredentials.fromStream(stream, null);
-      fail();
+      fail("Should throw if HttpTransportFactory is null");
     } catch (NullPointerException expected) {
       // Expected
     }
   }
 
   @Test
-  public void fromStream_nullStreamThrows() throws IOException {
+  public void fromStream_nullStream_Throws() throws IOException {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     try {
       ServiceAccountCredentials.fromStream(null, transportFactory);
-      fail();
+      fail("Should throw if InputStream is null");
     } catch (NullPointerException expected) {
       // Expected
     }
@@ -395,9 +395,8 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void fromStream_providesToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
-    InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+    InputStream serviceAccountStream = writeServiceAccountStream(
+        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 
     GoogleCredentials credentials =
         ServiceAccountCredentials.fromStream(serviceAccountStream, transportFactory);
@@ -410,36 +409,32 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void fromStream_noClientId_throws() throws IOException {
-    InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            null, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+    InputStream serviceAccountStream =
+        writeServiceAccountStream(null, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 
     testFromStreamException(serviceAccountStream, "client_id");
   }
 
   @Test
   public void fromStream_noClientEmail_throws() throws IOException {
-    InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            SA_CLIENT_ID, null, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+    InputStream serviceAccountStream =
+        writeServiceAccountStream(SA_CLIENT_ID, null, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 
     testFromStreamException(serviceAccountStream, "client_email");
   }
 
   @Test
   public void fromStream_noPrivateKey_throws() throws IOException {
-    InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            SA_CLIENT_ID, SA_CLIENT_EMAIL, null, SA_PRIVATE_KEY_ID);
+    InputStream serviceAccountStream =
+        writeServiceAccountStream(SA_CLIENT_ID, SA_CLIENT_EMAIL, null, SA_PRIVATE_KEY_ID);
 
     testFromStreamException(serviceAccountStream, "private_key");
   }
 
   @Test
   public void fromStream_noPrivateKeyId_throws() throws IOException {
-    InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, null);
+    InputStream serviceAccountStream =
+        writeServiceAccountStream(SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, null);
 
     testFromStreamException(serviceAccountStream, "private_key_id");
   }
@@ -463,7 +458,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     return json;
   }
 
-  static InputStream writeServiceAccountAccountStream(String clientId, String clientEmail,
+  static InputStream writeServiceAccountStream(String clientId, String clientEmail,
       String privateKeyPkcs8, String privateKeyId) throws IOException {
     GenericJson json =
         writeServiceAccountJson(clientId, clientEmail, privateKeyPkcs8, privateKeyId);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -31,6 +31,7 @@
 
 package com.google.auth.oauth2;
 
+import static com.google.auth.oauth2.GoogleCredentialsTest.testFromStreamException;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -42,6 +43,7 @@ import static org.junit.Assert.fail;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.util.Clock;
 import com.google.auth.TestUtils;
+import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.GoogleCredentialsTest.MockHttpTransportFactory;
 import com.google.auth.oauth2.GoogleCredentialsTest.MockTokenServerTransportFactory;
 import com.google.common.collect.ImmutableSet;
@@ -50,6 +52,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -92,6 +95,8 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   private static final Collection<String> SCOPES = Collections.singletonList("dummy.scope");
   private static final Collection<String> EMPTY_SCOPES = Collections.emptyList();
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
+  private static final HttpTransportFactory DUMMY_TRANSPORT_FACTORY =
+      new MockTokenServerTransportFactory();
 
   @Test
   public void createdScoped_clones() throws IOException {
@@ -362,6 +367,81 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());
     assertEquals(credentials.toString(), deserializedCredentials.toString());
     assertSame(deserializedCredentials.clock, Clock.SYSTEM);
+  }
+
+  @Test
+  public void fromStream_nullTransport_throws() throws IOException {
+    InputStream stream = new ByteArrayInputStream("foo".getBytes());
+    try {
+      ServiceAccountCredentials.fromStream(stream, null);
+      fail();
+    } catch (NullPointerException expected) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void fromStream_nullStreamThrows() throws IOException {
+    MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
+    try {
+      ServiceAccountCredentials.fromStream(null, transportFactory);
+      fail();
+    } catch (NullPointerException expected) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void fromStream_providesToken() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+    InputStream serviceAccountStream = ServiceAccountCredentialsTest
+        .writeServiceAccountAccountStream(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+
+    GoogleCredentials credentials =
+        ServiceAccountCredentials.fromStream(serviceAccountStream, transportFactory);
+
+    assertNotNull(credentials);
+    credentials = credentials.createScoped(SCOPES);
+    Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
+  }
+
+  @Test
+  public void fromStream_noClientId_throws() throws IOException {
+    InputStream serviceAccountStream = ServiceAccountCredentialsTest
+        .writeServiceAccountAccountStream(
+            null, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+
+    testFromStreamException(serviceAccountStream, "client_id");
+  }
+
+  @Test
+  public void fromStream_noClientEmail_throws() throws IOException {
+    InputStream serviceAccountStream = ServiceAccountCredentialsTest
+        .writeServiceAccountAccountStream(
+            SA_CLIENT_ID, null, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+
+    testFromStreamException(serviceAccountStream, "client_email");
+  }
+
+  @Test
+  public void fromStream_noPrivateKey_throws() throws IOException {
+    InputStream serviceAccountStream = ServiceAccountCredentialsTest
+        .writeServiceAccountAccountStream(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, null, SA_PRIVATE_KEY_ID);
+
+    testFromStreamException(serviceAccountStream, "private_key");
+  }
+
+  @Test
+  public void fromStream_noPrivateKeyId_throws() throws IOException {
+    InputStream serviceAccountStream = ServiceAccountCredentialsTest
+        .writeServiceAccountAccountStream(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, null);
+
+    testFromStreamException(serviceAccountStream, "private_key_id");
   }
 
   static GenericJson writeServiceAccountJson(

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -467,7 +467,8 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   private static void testFromStreamException(InputStream stream, String expectedMessageContent) {
     try {
       ServiceAccountCredentials.fromStream(stream, DUMMY_TRANSPORT_FACTORY);
-      fail();
+      fail(String.format("Should throw exception with message containing '%s'",
+          expectedMessageContent));
     } catch (IOException expected) {
       assertTrue(expected.getMessage().contains(expectedMessageContent));
     }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -381,7 +381,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void fromStream_nullStream_Throws() throws IOException {
+  public void fromStream_nullStream_throws() throws IOException {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     try {
       ServiceAccountCredentials.fromStream(null, transportFactory);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -446,7 +446,8 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   private static void testFromStreamException(InputStream stream, String expectedMessageContent) {
     try {
       ServiceAccountJwtAccessCredentials.fromStream(stream, CALL_URI);
-      fail();
+      fail(String.format("Should throw exception with message containing '%s'",
+          expectedMessageContent));
     } catch (IOException expected) {
       assertTrue(expected.getMessage().contains(expectedMessageContent));
     }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -354,11 +354,11 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   }
 
   @Test
-  public void fromStream_nullStreamThrows() throws IOException {
+  public void fromStream_nullStream_Throws() throws IOException {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     try {
       ServiceAccountCredentials.fromStream(null, transportFactory);
-      fail();
+      fail("Should throw if InputStream is null");
     } catch (NullPointerException expected) {
       // Expected
     }
@@ -367,7 +367,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void fromStream_hasJwtAccess() throws IOException {
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
+        .writeServiceAccountStream(
             SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 
     Credentials credentials =
@@ -381,7 +381,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void fromStream_defaultURI_hasJwtAccess() throws IOException {
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
+        .writeServiceAccountStream(
             SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 
     Credentials credentials =
@@ -395,8 +395,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void fromStream_noClientId_throws() throws IOException {
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            null, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+        .writeServiceAccountStream(null, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 
     testFromStreamException(serviceAccountStream, "client_id");
   }
@@ -404,8 +403,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void fromStream_noClientEmail_throws() throws IOException {
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            SA_CLIENT_ID, null, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+        .writeServiceAccountStream(SA_CLIENT_ID, null, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 
     testFromStreamException(serviceAccountStream, "client_email");
   }
@@ -413,8 +411,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void fromStream_noPrivateKey_throws() throws IOException {
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            SA_CLIENT_ID, SA_CLIENT_EMAIL, null, SA_PRIVATE_KEY_ID);
+        .writeServiceAccountStream(SA_CLIENT_ID, SA_CLIENT_EMAIL, null, SA_PRIVATE_KEY_ID);
 
     testFromStreamException(serviceAccountStream, "private_key");
   }
@@ -422,8 +419,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void fromStream_noPrivateKeyId_throws() throws IOException {
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
-        .writeServiceAccountAccountStream(
-            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, null);
+        .writeServiceAccountStream(SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, null);
 
     testFromStreamException(serviceAccountStream, "private_key_id");
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -31,7 +31,6 @@
 
 package com.google.auth.oauth2;
 
-import static com.google.auth.oauth2.GoogleCredentialsTest.testFromStreamException;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -442,5 +441,14 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
     assertEquals(expectedEmail, signature.getPayload().getSubject());
     assertEquals(expectedAudience.toString(), signature.getPayload().getAudience());
     assertEquals(expectedKeyId, signature.getHeader().getKeyId());
+  }
+
+  private static void testFromStreamException(InputStream stream, String expectedMessageContent) {
+    try {
+      ServiceAccountJwtAccessCredentials.fromStream(stream, CALL_URI);
+      fail();
+    } catch (IOException expected) {
+      assertTrue(expected.getMessage().contains(expectedMessageContent));
+    }
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -354,7 +354,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   }
 
   @Test
-  public void fromStream_nullStream_Throws() throws IOException {
+  public void fromStream_nullStream_throws() throws IOException {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     try {
       ServiceAccountCredentials.fromStream(null, transportFactory);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -31,6 +31,7 @@
 
 package com.google.auth.oauth2;
 
+import static com.google.auth.oauth2.GoogleCredentialsTest.testFromStreamException;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -46,12 +47,14 @@ import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.util.Clock;
 import com.google.auth.Credentials;
 import com.google.auth.http.AuthHttpConstants;
+import com.google.auth.oauth2.GoogleCredentialsTest.MockHttpTransportFactory;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -348,6 +351,81 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
     assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());
     assertEquals(credentials.toString(), deserializedCredentials.toString());
     assertSame(deserializedCredentials.clock, Clock.SYSTEM);
+  }
+
+  @Test
+  public void fromStream_nullStreamThrows() throws IOException {
+    MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
+    try {
+      ServiceAccountCredentials.fromStream(null, transportFactory);
+      fail();
+    } catch (NullPointerException expected) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void fromStream_hasJwtAccess() throws IOException {
+    InputStream serviceAccountStream = ServiceAccountCredentialsTest
+        .writeServiceAccountAccountStream(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+
+    Credentials credentials =
+        ServiceAccountJwtAccessCredentials.fromStream(serviceAccountStream);
+
+    assertNotNull(credentials);
+    Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
+    verifyJwtAccess(metadata, SA_CLIENT_EMAIL, CALL_URI, SA_PRIVATE_KEY_ID);
+  }
+
+  @Test
+  public void fromStream_defaultURI_hasJwtAccess() throws IOException {
+    InputStream serviceAccountStream = ServiceAccountCredentialsTest
+        .writeServiceAccountAccountStream(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+
+    Credentials credentials =
+        ServiceAccountJwtAccessCredentials.fromStream(serviceAccountStream, CALL_URI);
+
+    assertNotNull(credentials);
+    Map<String, List<String>> metadata = credentials.getRequestMetadata(null);
+    verifyJwtAccess(metadata, SA_CLIENT_EMAIL, CALL_URI, SA_PRIVATE_KEY_ID);
+  }
+
+  @Test
+  public void fromStream_noClientId_throws() throws IOException {
+    InputStream serviceAccountStream = ServiceAccountCredentialsTest
+        .writeServiceAccountAccountStream(
+            null, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+
+    testFromStreamException(serviceAccountStream, "client_id");
+  }
+
+  @Test
+  public void fromStream_noClientEmail_throws() throws IOException {
+    InputStream serviceAccountStream = ServiceAccountCredentialsTest
+        .writeServiceAccountAccountStream(
+            SA_CLIENT_ID, null, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+
+    testFromStreamException(serviceAccountStream, "client_email");
+  }
+
+  @Test
+  public void fromStream_noPrivateKey_throws() throws IOException {
+    InputStream serviceAccountStream = ServiceAccountCredentialsTest
+        .writeServiceAccountAccountStream(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, null, SA_PRIVATE_KEY_ID);
+
+    testFromStreamException(serviceAccountStream, "private_key");
+  }
+
+  @Test
+  public void fromStream_noPrivateKeyId_throws() throws IOException {
+    InputStream serviceAccountStream = ServiceAccountCredentialsTest
+        .writeServiceAccountAccountStream(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, null);
+
+    testFromStreamException(serviceAccountStream, "private_key_id");
   }
 
   private void verifyJwtAccess(Map<String, List<String>> metadata, String expectedEmail,

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
@@ -334,8 +334,7 @@ public class UserCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
-    InputStream userStream =
-        UserCredentialsTest.writeUserStream(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN);
+    InputStream userStream = writeUserStream(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN);
 
     UserCredentials credentials = UserCredentials.fromStream(userStream, transportFactory);
 
@@ -346,24 +345,21 @@ public class UserCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void fromStream_userNoClientId_throws() throws IOException {
-    InputStream userStream =
-        UserCredentialsTest.writeUserStream(null, CLIENT_SECRET, REFRESH_TOKEN);
+    InputStream userStream = writeUserStream(null, CLIENT_SECRET, REFRESH_TOKEN);
 
     testFromStreamException(userStream, "client_id");
   }
 
   @Test
   public void fromStream_userNoClientSecret_throws() throws IOException {
-    InputStream userStream =
-        UserCredentialsTest.writeUserStream(CLIENT_ID, null, REFRESH_TOKEN);
+    InputStream userStream = writeUserStream(CLIENT_ID, null, REFRESH_TOKEN);
 
     testFromStreamException(userStream, "client_secret");
   }
 
   @Test
   public void fromStream_userNoRefreshToken_throws() throws IOException {
-    InputStream userStream =
-        UserCredentialsTest.writeUserStream(CLIENT_ID, CLIENT_SECRET, null);
+    InputStream userStream = writeUserStream(CLIENT_ID, CLIENT_SECRET, null);
 
     testFromStreamException(userStream, "refresh_token");
   }
@@ -392,7 +388,8 @@ public class UserCredentialsTest extends BaseSerializationTest {
   private static void testFromStreamException(InputStream stream, String expectedMessageContent) {
     try {
       UserCredentials.fromStream(stream);
-      fail();
+      fail(String.format("Should throw exception with message containing '%s'",
+          expectedMessageContent));
     } catch (IOException expected) {
       assertTrue(expected.getMessage().contains(expectedMessageContent));
     }


### PR DESCRIPTION
While integrating this library with `google-cloud-java` I realized there is no easy way to create `ServiceAccountCredentials` and `ServiceAccountJwtAccessCredentials` from a JSON credentials file.

It's important to have such methods for users that are willing to create an implementation of `ServiceAccountSigner`. The factory method `fromStream` in `GoogleCredentials` is not a good fit as it would require casting to get a `ServiceAccountCredentials` instance.

This should probably trigger a new release, I wish I had identified this earlier.

/cc @garrettjonesgoogle @anthmgoogle @lesv 