### PR TITLE
Fix a trivial typo and remove redundancy

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -181,7 +181,7 @@ public class OAuth2Credentials extends Credentials {
   public AccessToken refreshAccessToken() throws IOException {
     throw new IllegalStateException("OAuth2Credentials instance does not support refreshing the"
         + " access token. An instance with a new access token should be used, or a derived type"
-        + " that supports refreshing should be used.");
+        + " that supports refreshing.");
   }
 
   /**

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -275,7 +275,7 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
   @Override
   public AccessToken refreshAccessToken() throws IOException {
     if (createScopedRequired()) {
-      throw new IOException("Scopes not configured for service account. Scoped should be specifed"
+      throw new IOException("Scopes not configured for service account. Scoped should be specified"
           + " by calling createScoped or passing scopes to constructor.");
     }
 


### PR DESCRIPTION
s/specifed/specified

And remove redundancy (should be used) in exception message.