### PR TITLE
Look for CREDENTIAL_ENV_VAR in system properties when no envvar available

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -122,6 +122,9 @@ class DefaultCredentialsProvider {
     // First try the environment variable
     GoogleCredentials credentials = null;
     String credentialsPath = getEnv(CREDENTIAL_ENV_VAR);
+    if (credentialsPath == null) {
+        credentialsPath = getProperty(CREDENTIAL_ENV_VAR, null);
+    }
     if (credentialsPath != null && credentialsPath.length() > 0) {
       InputStream credentialsStream = null;
       try {


### PR DESCRIPTION
Hello,

At the moment, the code looks for the CREDENTIAL_ENV_VAR (i.e. GOOGLE_APPLICATION_CREDENTIALS) in the environment variables.

When an application using, for example, Google Natural Language, is deployed to Amazon AWS, developers are able to specify only [system properties](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/java-configuration.html).

The easiest [way I found](http://kinoshita.eti.br/2017/03/15/using-google-natural-language-api-in-aws-elastic-beanstalk-application/) to deploy this application was creating a LanguageServiceSettings and creating scoped GoogleCredentials from a file manually.

In this pull request, the change is to fallback to system properties when there are no environment variables.

Hope that helps someone else with a similar problem.

Cheers
Bruno