### PR TITLE
Retry GCE environment check for Application Default Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ following are searched (in order) to find the Application Default Credentials:
 3. Google App Engine built-in credentials
 4. Google Cloud Shell built-in credentials
 5. Google Compute Engine built-in credentials
+   - Skip this check by setting the environment variable `NO_GCE_CHECK=true`
+   - Customize the GCE metadata server address by setting the environment variable `GCE_METADATA_HOST=<hostname>`
 
 To get Credentials from a Service Account JSON key use `GoogleCredentials.fromStream(InputStream)`
 or `GoogleCredentials.fromStream(InputStream, HttpTransportFactory)`.

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -59,10 +59,10 @@ import java.util.logging.Logger;
  */
 public class ComputeEngineCredentials extends GoogleCredentials {
 
-  // Note: the explicit IP address is used to avoid name server resolution issues.
-  private static final String DEFAULT_METADATA_SERVER_URL = "http://169.254.169.254";
-
   private static final Logger LOGGER = Logger.getLogger(ComputeEngineCredentials.class.getName());
+
+  // Note: the explicit IP address is used to avoid name server resolution issues.
+  static final String DEFAULT_METADATA_SERVER_URL = "http://169.254.169.254";
 
   // Note: the explicit `timeout` and `tries` below is a workaround. The underlying
   // issue is that resolving an unknown host on some networks will take
@@ -185,15 +185,19 @@ public class ComputeEngineCredentials extends GoogleCredentials {
     if (metadataServerAddress != null) {
       return "http://" + metadataServerAddress;
     }
-    return getMetadataServerUrl();
-  }
-
-  public static String getMetadataServerUrl() {
     return DEFAULT_METADATA_SERVER_URL;
   }
 
+  public static String getMetadataServerUrl() {
+    return getMetadataServerUrl(DefaultCredentialsProvider.DEFAULT);
+  }
+
+  public static String getTokenServerEncodedUrl(DefaultCredentialsProvider provider) {
+    return getMetadataServerUrl(provider) + "/computeMetadata/v1/instance/service-accounts/default/token";
+  }
+
   public static String getTokenServerEncodedUrl() {
-    return getMetadataServerUrl() + "/computeMetadata/v1/instance/service-accounts/default/token";
+    return getTokenServerEncodedUrl(DefaultCredentialsProvider.DEFAULT);
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -259,7 +259,7 @@ class DefaultCredentialsProvider {
       return null;
     }
     boolean runningOnComputeEngine =
-        ComputeEngineCredentials.runningOnComputeEngine(transportFactory);
+        ComputeEngineCredentials.runningOnComputeEngine(transportFactory, this);
     checkedComputeEngine = true;
     if (runningOnComputeEngine) {
       return new ComputeEngineCredentials(transportFactory);

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -53,6 +53,8 @@ import java.util.Locale;
  **/
 class DefaultCredentialsProvider {
 
+  static final DefaultCredentialsProvider DEFAULT = new DefaultCredentialsProvider();
+
   static final String CREDENTIAL_ENV_VAR = "GOOGLE_APPLICATION_CREDENTIALS";
 
   static final String WELL_KNOWN_CREDENTIALS_FILE = "application_default_credentials.json";

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -68,6 +68,9 @@ class DefaultCredentialsProvider {
 
   static final String SKIP_APP_ENGINE_ENV_VAR = "GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE";
 
+  static final String NO_GCE_CHECK_ENV_VAR = "NO_GCE_CHECK";
+  static final String GCE_METADATA_HOST_ENV_VAR = "GCE_METADATA_HOST";
+
   // These variables should only be accessed inside a synchronized block
   private GoogleCredentials cachedCredentials = null;
   private boolean checkedAppEngine = false;

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -34,7 +34,6 @@ package com.google.auth.oauth2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -335,11 +334,21 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_envGceMetadataHost_setsUrl() {
+  public void getDefaultCredentials_envGceMetadataHost_setsMetadataServerUrl() {
     String testUrl = "192.0.2.0";
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.setEnv(DefaultCredentialsProvider.GCE_METADATA_HOST_ENV_VAR, testUrl);
     assertEquals(ComputeEngineCredentials.getMetadataServerUrl(testProvider), "http://" + testUrl);
+  }
+
+  @Test
+  public void getDefaultCredentials_envGceMetadataHost_setsTokenServerUrl() {
+    String testUrl = "192.0.2.0";
+    TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
+    testProvider.setEnv(DefaultCredentialsProvider.GCE_METADATA_HOST_ENV_VAR, testUrl);
+    assertEquals(
+        ComputeEngineCredentials.getTokenServerEncodedUrl(testProvider),
+        "http://" + testUrl + "/computeMetadata/v1/instance/service-accounts/default/token");
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
@@ -63,7 +63,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
 
   @Override
   public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
-    if (url.equals(ComputeEngineCredentials.TOKEN_SERVER_ENCODED_URL)) {
+    if (url.equals(ComputeEngineCredentials.getTokenServerEncodedUrl())) {
 
       return new MockLowLevelHttpRequest(url) {
         @Override
@@ -93,7 +93,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
             .setContent(refreshText);
         }
       };
-    } else if (url.equals(ComputeEngineCredentials.METADATA_SERVER_URL)) {
+    } else if (url.equals(ComputeEngineCredentials.getMetadataServerUrl())) {
       return new MockLowLevelHttpRequest(url) {
         @Override
         public LowLevelHttpResponse execute() {


### PR DESCRIPTION
Adapt fix from Apiary client libraries. Currently untested.

Addresses #109.