### PR TITLE
Fixing an Integer Overflow Issue

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -383,7 +383,7 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
         responseData, "access_token", PARSE_ERROR_PREFIX);
     int expiresInSeconds = OAuth2Utils.validateInt32(
         responseData, "expires_in", PARSE_ERROR_PREFIX);
-    long expiresAtMilliseconds = clock.currentTimeMillis() + expiresInSeconds * 1000;
+    long expiresAtMilliseconds = clock.currentTimeMillis() + expiresInSeconds * 1000L;
     return new AccessToken(accessToken, new Date(expiresAtMilliseconds));
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -65,6 +65,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
   private IOException error;
   private Queue<IOException> responseErrorSequence = new ArrayDeque<IOException>();
   private Queue<LowLevelHttpResponse> responseSequence = new ArrayDeque<LowLevelHttpResponse>();
+  private int expiresInSeconds = 3600;
 
   public MockTokenServerTransport() {}
 
@@ -111,6 +112,10 @@ public class MockTokenServerTransport extends MockHttpTransport {
     for (LowLevelHttpResponse response : responses) {
       responseSequence.add(response);
     }
+  }
+
+  public void setExpiresInSeconds(int expiresInSeconds) {
+    this.expiresInSeconds = expiresInSeconds;
   }
 
   @Override
@@ -187,7 +192,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
           GenericJson refreshContents = new GenericJson();
           refreshContents.setFactory(JSON_FACTORY);
           refreshContents.put("access_token", accessToken);
-          refreshContents.put("expires_in", 3600);
+          refreshContents.put("expires_in", expiresInSeconds);
           refreshContents.put("token_type", "Bearer");
           if (refreshToken != null) {
             refreshContents.put("refresh_token", refreshToken);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -98,6 +98,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   private static final String ACCESS_TOKEN = "1/MkSJoj1xsli0AccessToken_NKPY2";
   private static final Collection<String> SCOPES = Collections.singletonList("dummy.scope");
   private static final String SERVICE_ACCOUNT_USER = "user@example.com";
+  private static final String PROJECT_ID = "project-id";
   private static final Collection<String> EMPTY_SCOPES = Collections.emptyList();
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
   private static final HttpTransportFactory DUMMY_TRANSPORT_FACTORY =
@@ -107,7 +108,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void createdScoped_clones() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     GoogleCredentials credentials = new ServiceAccountCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, SCOPES, null, null, SERVICE_ACCOUNT_USER);
+        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, SCOPES, null, null, SERVICE_ACCOUNT_USER, PROJECT_ID);
     List<String> newScopes = Arrays.asList("scope1", "scope2");
 
     ServiceAccountCredentials newCredentials =
@@ -119,6 +120,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     assertEquals(SA_PRIVATE_KEY_ID, newCredentials.getPrivateKeyId());
     assertArrayEquals(newScopes.toArray(), newCredentials.getScopes().toArray());
     assertEquals(SERVICE_ACCOUNT_USER, newCredentials.getServiceAccountUser());
+    assertEquals(PROJECT_ID, newCredentials.getProjectId());
 
     assertArrayEquals(SCOPES.toArray(), ((ServiceAccountCredentials)credentials).getScopes().toArray());
   }
@@ -127,7 +129,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void createdDelegated_clones() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     GoogleCredentials credentials = new ServiceAccountCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, SCOPES, null, null, SERVICE_ACCOUNT_USER);
+        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, SCOPES, null, null, SERVICE_ACCOUNT_USER, PROJECT_ID);
     String newServiceAccountUser = "stranger@other.org";
 
     ServiceAccountCredentials newCredentials =
@@ -139,6 +141,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     assertEquals(SA_PRIVATE_KEY_ID, newCredentials.getPrivateKeyId());
     assertArrayEquals(SCOPES.toArray(), newCredentials.getScopes().toArray());
     assertEquals(newServiceAccountUser, newCredentials.getServiceAccountUser());
+    assertEquals(PROJECT_ID, newCredentials.getProjectId());
 
     assertEquals(SERVICE_ACCOUNT_USER, ((ServiceAccountCredentials)credentials).getServiceAccountUser());
 }
@@ -148,7 +151,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     List<String> scopes = Arrays.asList("scope1", "scope2");
     ServiceAccountCredentials credentials = new ServiceAccountCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, scopes, null, null, SERVICE_ACCOUNT_USER);
+        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, scopes, null, null, SERVICE_ACCOUNT_USER, PROJECT_ID);
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
@@ -201,11 +204,22 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
+  public void fromJSON_getProjectId() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+    GenericJson json = writeServiceAccountJson(
+        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, PROJECT_ID);
+
+    ServiceAccountCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
+    assertEquals(PROJECT_ID, credentials.getProjectId());
+  }
+
+  @Test
   public void fromJSON_hasAccessToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
     GenericJson json = writeServiceAccountJson(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, PROJECT_ID);
 
     GoogleCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
 
@@ -618,7 +632,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   }
 
   static GenericJson writeServiceAccountJson(
-      String clientId, String clientEmail, String privateKeyPkcs8, String privateKeyId) {
+      String clientId, String clientEmail, String privateKeyPkcs8, String privateKeyId, String projectId) {
     GenericJson json = new GenericJson();
     if (clientId != null) {
       json.put("client_id", clientId);
@@ -632,6 +646,9 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     if (privateKeyId != null) {
       json.put("private_key_id", privateKeyId);
     }
+    if (projectId != null) {
+      json.put("project_id", projectId);
+    }
     json.put("type", GoogleCredentials.SERVICE_ACCOUNT_FILE_TYPE);
     return json;
   }
@@ -639,7 +656,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   static InputStream writeServiceAccountStream(String clientId, String clientEmail,
       String privateKeyPkcs8, String privateKeyId) throws IOException {
     GenericJson json =
-        writeServiceAccountJson(clientId, clientEmail, privateKeyPkcs8, privateKeyId);
+        writeServiceAccountJson(clientId, clientEmail, privateKeyPkcs8, privateKeyId, null);
     return TestUtils.jsonToInputStream(json);
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -212,6 +213,17 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     ServiceAccountCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
     assertEquals(PROJECT_ID, credentials.getProjectId());
+  }
+
+  @Test
+  public void fromJSON_getProjectIdNull() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+    GenericJson json = writeServiceAccountJson(
+        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null);
+
+    ServiceAccountCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
+    assertNull(credentials.getProjectId());
   }
 
   @Test


### PR DESCRIPTION
If the token server responds with a large `expires_in` value to the token refresh request, the `ServiceAccountCredential` class runs into an integer overflow. I've added more information at #120.

This patch fixes the issue, and provides a test case (test case fails without the fix). This is not a critical issue, as we can expect most token servers to be well behaved. But it would be nice if the credentials were able to handle the case where the server responds with a large `expires_in` value. 