### PR TITLE
use metadata server to get credentials for GAE 8 standard environment

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -175,20 +175,20 @@ class DefaultCredentialsProvider {
       }
     }
 
-    // Then try App Engine
-    if (credentials == null && !skipAppEngineCredentialsCheck()) {
-      credentials = tryGetAppEngineCredential();
-    }
-
     // Then try Cloud Shell.  This must be done BEFORE checking
     // Compute Engine, as Cloud Shell runs on GCE VMs.
     if (credentials == null) {
       credentials = tryGetCloudShellCredentials();
     }
 
-    // Then try Compute Engine
+    // Then try Compute Engine and GAE 8 standard environment
     if (credentials == null) {
       credentials = tryGetComputeCredentials(transportFactory);
+    }
+
+    // Then try GAE 7 standard environment
+    if (credentials == null && !skipAppEngineCredentialsCheck()) {
+      credentials = tryGetAppEngineCredential();
     }
 
     return credentials;

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -187,6 +187,7 @@ public class DefaultCredentialsProviderTest {
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.addType(DefaultCredentialsProvider.APP_ENGINE_SIGNAL_CLASS,
         MockOffAppEngineSystemProperty.class);
+    testProvider.setProperty("isOnGAEStandard7", "true");
 
     try {
       testProvider.getDefaultCredentials(transportFactory);
@@ -203,6 +204,7 @@ public class DefaultCredentialsProviderTest {
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.addType(DefaultCredentialsProvider.APP_ENGINE_SIGNAL_CLASS,
         MockAppEngineSystemProperty.class);
+    testProvider.setProperty("isOnGAEStandard7", "true");
 
     try {
       testProvider.getDefaultCredentials(transportFactory);
@@ -223,6 +225,7 @@ public class DefaultCredentialsProviderTest {
         MockOffAppEngineSystemProperty.class);
     testProvider.setEnv(DefaultCredentialsProvider.CLOUD_SHELL_ENV_VAR,"9090");
     testProvider.setEnv(DefaultCredentialsProvider.SKIP_APP_ENGINE_ENV_VAR, "true");
+    testProvider.setProperty("isOnGAEStanadard7", "true");
     GoogleCredentials credentials = testProvider.getDefaultCredentials(transportFactory);
     assertNotNull(credentials);
     assertTrue(credentials instanceof CloudShellCredentials);
@@ -576,6 +579,11 @@ public class DefaultCredentialsProviderTest {
         return lookup;
       }
       throw new ClassNotFoundException("TestDefaultCredentialProvider: Class not found.");
+    }
+
+    @Override
+    protected boolean isOnGAEStandard7() {
+      return getProperty("isOnGAEStandard7", "false").equals("true");
     }
 
     int getForNameCallCount() {


### PR DESCRIPTION
GAE java 8 standard environment supports Java native threads.  However `getDefaultCredentials()` call will fail on GAE J8 if it is called in a native thread (i.e. threads not managed by appengine runtime) due to the inaccessibility of native threads to appengine APIs. For GAE java8, same as compute engine, metadata serve should be used to construct `Credentials`.