### PR TITLE
Switch OAuth2 HTTP surface to use builder pattern

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ClientId.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ClientId.java
@@ -114,14 +114,6 @@ public class ClientId {
     return fromJson(parsedJson);
   }
 
-  public static Builder newBuilder() {
-    return new Builder();
-  }
-
-  public Builder toBuilder() {
-    return new Builder(this);
-  }
-
   /**
    * Constructs a client ID using an explicit ID and secret
    *
@@ -149,6 +141,14 @@ public class ClientId {
    */
   public final String getClientSecret() {
     return clientSecret;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
   }
 
   public static class Builder {

--- a/oauth2_http/java/com/google/auth/oauth2/ClientId.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ClientId.java
@@ -114,6 +114,14 @@ public class ClientId {
     return fromJson(parsedJson);
   }
 
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
   /**
    * Constructs a client ID using an explicit ID and secret
    *
@@ -123,7 +131,7 @@ public class ClientId {
    * @param clientId Text identifier of the Client ID.
    * @param clientSecret Secret to associated with the Client ID.
    */
-  public ClientId(String clientId, String clientSecret) {
+  protected ClientId(String clientId, String clientSecret) {
     this.clientId = Preconditions.checkNotNull(clientId);
     this.clientSecret = clientSecret;
   }
@@ -140,5 +148,37 @@ public class ClientId {
    */
   public final String getClientSecret() {
     return clientSecret;
+  }
+
+  public static class Builder {
+
+    private String clientId;
+
+    private String clientSecret;
+
+    protected Builder() {}
+
+    protected Builder(ClientId clientId) {
+      this.clientId = clientId.getClientId();
+      this.clientSecret = clientId.getClientSecret();
+    }
+
+    public Builder setClientId(String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    public Builder setClientSecret(String clientSecret) {
+      this.clientSecret = clientSecret;
+      return this;
+    }
+
+    public String getClientSecret() {
+      return clientSecret;
+    }
+
+    public ClientId build() {
+      return new ClientId(clientId, clientSecret);
+    }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/ClientId.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ClientId.java
@@ -131,7 +131,8 @@ public class ClientId {
    * @param clientId Text identifier of the Client ID.
    * @param clientSecret Secret to associated with the Client ID.
    */
-  protected ClientId(String clientId, String clientSecret) {
+  @Deprecated
+  public ClientId(String clientId, String clientSecret) {
     this.clientId = Preconditions.checkNotNull(clientId);
     this.clientSecret = clientSecret;
   }

--- a/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
@@ -63,7 +63,12 @@ public class CloudShellCredentials extends GoogleCredentials {
 
   private final int authPort;
 
-  protected CloudShellCredentials(int authPort) {
+  public static CloudShellCredentials of(int authPort) {
+    return CloudShellCredentials.newBuilder().setAuthPort(authPort).build();
+  }
+
+  @Deprecated
+  public CloudShellCredentials(int authPort) {
     this.authPort = authPort;
   }
 
@@ -124,8 +129,10 @@ public class CloudShellCredentials extends GoogleCredentials {
   public static class Builder extends GoogleCredentials.Builder {
     private int authPort;
 
-    public GoogleCredentials build() {
-      return new CloudShellCredentials(authPort);
+    protected Builder() {}
+
+    protected Builder(CloudShellCredentials credentials) {
+      this.authPort = credentials.authPort;
     }
 
     public Builder setAuthPort(int authPort) {
@@ -137,10 +144,8 @@ public class CloudShellCredentials extends GoogleCredentials {
       return authPort;
     }
 
-    protected Builder() {}
-
-    protected Builder(CloudShellCredentials credentials) {
-      this.authPort = credentials.authPort;
+    public CloudShellCredentials build() {
+      return new CloudShellCredentials(authPort);
     }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
@@ -63,7 +63,7 @@ public class CloudShellCredentials extends GoogleCredentials {
 
   private final int authPort;
 
-  public CloudShellCredentials(int authPort) {
+  protected CloudShellCredentials(int authPort) {
     this.authPort = authPort;
   }
 
@@ -111,5 +111,36 @@ public class CloudShellCredentials extends GoogleCredentials {
     }
     CloudShellCredentials other = (CloudShellCredentials) obj;
     return this.authPort == other.authPort;
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder extends GoogleCredentials.Builder {
+    private int authPort;
+
+    public GoogleCredentials build() {
+      return new CloudShellCredentials(authPort);
+    }
+
+    public Builder setAuthPort(int authPort) {
+      this.authPort = authPort;
+      return this;
+    }
+
+    public int getAuthPort() {
+      return authPort;
+    }
+
+    protected Builder() {}
+
+    protected Builder(CloudShellCredentials credentials) {
+      this.authPort = credentials.authPort;
+    }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -82,13 +82,23 @@ public class ComputeEngineCredentials extends GoogleCredentials {
 
   private transient HttpTransportFactory transportFactory;
 
+   /**
+    * Constructor with minimum information and default behavior.
+    */
+   @Deprecated
+   public ComputeEngineCredentials() {
+     this(null);
+   }
+
+
   /**
    * Constructor with overridden transport.
    *
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.
    */
-  protected ComputeEngineCredentials(HttpTransportFactory transportFactory) {
+  @Deprecated
+  public ComputeEngineCredentials(HttpTransportFactory transportFactory) {
     this.transportFactory = firstNonNull(transportFactory,
         getFromServiceLoader(HttpTransportFactory.class, OAuth2Utils.HTTP_TRANSPORT_FACTORY));
     this.transportFactoryClassName = this.transportFactory.getClass().getName();
@@ -230,8 +240,10 @@ public class ComputeEngineCredentials extends GoogleCredentials {
   public static class Builder extends GoogleCredentials.Builder {
     private HttpTransportFactory transportFactory;
 
-    public ComputeEngineCredentials build() {
-      return new ComputeEngineCredentials(transportFactory);
+    protected Builder() {}
+
+    protected Builder(ComputeEngineCredentials credentials) {
+      this.transportFactory = credentials.transportFactory;
     }
 
     public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
@@ -243,10 +255,8 @@ public class ComputeEngineCredentials extends GoogleCredentials {
       return transportFactory;
     }
 
-    protected Builder() {}
-
-    protected Builder(ComputeEngineCredentials credentials) {
-      this.transportFactory = credentials.transportFactory;
+    public ComputeEngineCredentials build() {
+      return new ComputeEngineCredentials(transportFactory);
     }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -83,6 +83,16 @@ public class ComputeEngineCredentials extends GoogleCredentials {
   private transient HttpTransportFactory transportFactory;
 
   /**
+   * Returns a credentials instance from the given transport factory
+   *
+   * @param transportFactory The Http transport factory
+   * @return the credential instance
+   */
+  public static ComputeEngineCredentials of(HttpTransportFactory transportFactory) {
+    return ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+  }
+
+  /**
    * Constructor with minimum information and default behavior.
    */
   @Deprecated

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -82,14 +82,13 @@ public class ComputeEngineCredentials extends GoogleCredentials {
 
   private transient HttpTransportFactory transportFactory;
 
-   /**
-    * Constructor with minimum information and default behavior.
-    */
-   @Deprecated
-   public ComputeEngineCredentials() {
-     this(null);
-   }
-
+  /**
+   * Constructor with minimum information and default behavior.
+   */
+  @Deprecated
+  public ComputeEngineCredentials() {
+    this(null);
+  }
 
   /**
    * Constructor with overridden transport.

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -83,19 +83,12 @@ public class ComputeEngineCredentials extends GoogleCredentials {
   private transient HttpTransportFactory transportFactory;
 
   /**
-   * Constructor with minimum information and default behavior.
-   */
-  public ComputeEngineCredentials() {
-    this(null);
-  }
-
-  /**
    * Constructor with overridden transport.
    *
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.
    */
-  public ComputeEngineCredentials(HttpTransportFactory transportFactory) {
+  protected ComputeEngineCredentials(HttpTransportFactory transportFactory) {
     this.transportFactory = firstNonNull(transportFactory,
         getFromServiceLoader(HttpTransportFactory.class, OAuth2Utils.HTTP_TRANSPORT_FACTORY));
     this.transportFactoryClassName = this.transportFactory.getClass().getName();
@@ -224,5 +217,36 @@ public class ComputeEngineCredentials extends GoogleCredentials {
   private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
     input.defaultReadObject();
     transportFactory = newInstance(transportFactoryClassName);
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder extends GoogleCredentials.Builder {
+    private HttpTransportFactory transportFactory;
+
+    public ComputeEngineCredentials build() {
+      return new ComputeEngineCredentials(transportFactory);
+    }
+
+    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+      this.transportFactory = transportFactory;
+      return this;
+    }
+
+    public HttpTransportFactory getHttpTransportFactory() {
+      return transportFactory;
+    }
+
+    protected Builder() {}
+
+    protected Builder(ComputeEngineCredentials credentials) {
+      this.transportFactory = credentials.transportFactory;
+    }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -167,8 +167,16 @@ public class GoogleCredentials extends OAuth2Credentials {
    *
    * @param accessToken Initial or temporary access token.
    **/
-  public GoogleCredentials(AccessToken accessToken) {
+  protected GoogleCredentials(AccessToken accessToken) {
     super(accessToken);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
   }
 
   /**
@@ -194,5 +202,22 @@ public class GoogleCredentials extends OAuth2Credentials {
    */
   public GoogleCredentials createDelegated(String user) {
     return this;
+  }
+
+  public static class Builder extends OAuth2Credentials.Builder {
+    public GoogleCredentials build() {
+      return new GoogleCredentials(getAccessToken());
+    }
+
+    public Builder setAccessToken(AccessToken token) {
+      super.setAccessToken(token);
+      return this;
+    }
+
+    protected Builder() {}
+
+    protected Builder(GoogleCredentials credentials) {
+      setAccessToken(credentials.getAccessToken());
+    }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -54,6 +54,16 @@ public class GoogleCredentials extends OAuth2Credentials {
       new DefaultCredentialsProvider();
 
   /**
+   * Returns the credentials instance from the given access token.
+   *
+   * @param accessToken the access token
+   * @return the credentials instance
+   */
+  public static GoogleCredentials of(AccessToken accessToken) {
+    return GoogleCredentials.newBuilder().setAccessToken(accessToken).build();
+  }
+
+  /**
    * Returns the Application Default Credentials.
    *
    * <p>Returns the Application Default Credentials which are used to identify and authorize the
@@ -158,7 +168,8 @@ public class GoogleCredentials extends OAuth2Credentials {
   /**
    * Default constructor.
    **/
-  protected GoogleCredentials() {
+  @Deprecated
+  public GoogleCredentials() {
     this(null);
   }
 
@@ -205,19 +216,20 @@ public class GoogleCredentials extends OAuth2Credentials {
   }
 
   public static class Builder extends OAuth2Credentials.Builder {
-    public GoogleCredentials build() {
-      return new GoogleCredentials(getAccessToken());
-    }
-
-    public Builder setAccessToken(AccessToken token) {
-      super.setAccessToken(token);
-      return this;
-    }
-
     protected Builder() {}
 
     protected Builder(GoogleCredentials credentials) {
       setAccessToken(credentials.getAccessToken());
+    }
+
+    public GoogleCredentials build() {
+      return new GoogleCredentials(getAccessToken());
+    }
+
+    @Override
+    public Builder setAccessToken(AccessToken token) {
+      super.setAccessToken(token);
+      return this;
     }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -168,8 +168,7 @@ public class GoogleCredentials extends OAuth2Credentials {
   /**
    * Default constructor.
    **/
-  @Deprecated
-  public GoogleCredentials() {
+  protected GoogleCredentials() {
     this(null);
   }
 
@@ -178,7 +177,8 @@ public class GoogleCredentials extends OAuth2Credentials {
    *
    * @param accessToken Initial or temporary access token.
    **/
-  protected GoogleCredentials(AccessToken accessToken) {
+  @Deprecated
+  public GoogleCredentials(AccessToken accessToken) {
     super(accessToken);
   }
 

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -85,8 +85,7 @@ public class OAuth2Credentials extends Credentials {
   /**
    * Default constructor.
    **/
-  @Deprecated
-  public OAuth2Credentials() {
+  protected OAuth2Credentials() {
     this(null);
   }
 

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -75,7 +75,8 @@ public class OAuth2Credentials extends Credentials {
   /**
    * Default constructor.
    **/
-  private OAuth2Credentials() {
+  @Deprecated
+  public OAuth2Credentials() {
     this(null);
   }
 
@@ -84,7 +85,8 @@ public class OAuth2Credentials extends Credentials {
    *
    * @param accessToken Initial or temporary access token.
    **/
-  protected OAuth2Credentials(AccessToken accessToken) {
+  @Deprecated
+  public OAuth2Credentials(AccessToken accessToken) {
     if (accessToken != null) {
       useAccessToken(accessToken);
     }
@@ -153,14 +155,6 @@ public class OAuth2Credentials extends Credentials {
         }
       }
     }
-  }
-
-  public static Builder newBuilder() {
-    return new Builder();
-  }
-
-  public Builder toBuilder() {
-    return new Builder(this);
   }
 
   // Must be called under lock
@@ -288,9 +282,23 @@ public class OAuth2Credentials extends Credentials {
     return Iterables.getFirst(ServiceLoader.load(clazz), defaultInstance);
   }
 
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
   public static class Builder {
 
     private AccessToken accessToken;
+
+    protected Builder() {}
+
+    protected Builder(OAuth2Credentials credentials) {
+      this.accessToken = credentials.getAccessToken();
+    }
 
     public Builder setAccessToken(AccessToken token) {
       this.accessToken = token;
@@ -303,12 +311,6 @@ public class OAuth2Credentials extends Credentials {
 
     public OAuth2Credentials build() {
       return new OAuth2Credentials(accessToken);
-    }
-
-    protected Builder() {}
-
-    protected Builder(OAuth2Credentials credentials) {
-      this.accessToken = credentials.getAccessToken();
     }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -73,6 +73,16 @@ public class OAuth2Credentials extends Credentials {
   transient Clock clock = Clock.SYSTEM;
 
   /**
+   * Returns the credentials instance from the given access token.
+   *
+   * @param accessToken the access token
+   * @return the credentials instance
+   */
+  public static OAuth2Credentials of(AccessToken accessToken) {
+    return OAuth2Credentials.newBuilder().setAccessToken(accessToken).build();
+  }
+
+  /**
    * Default constructor.
    **/
   @Deprecated

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -75,7 +75,7 @@ public class OAuth2Credentials extends Credentials {
   /**
    * Default constructor.
    **/
-  protected OAuth2Credentials() {
+  private OAuth2Credentials() {
     this(null);
   }
 
@@ -84,7 +84,7 @@ public class OAuth2Credentials extends Credentials {
    *
    * @param accessToken Initial or temporary access token.
    **/
-  public OAuth2Credentials(AccessToken accessToken) {
+  protected OAuth2Credentials(AccessToken accessToken) {
     if (accessToken != null) {
       useAccessToken(accessToken);
     }
@@ -153,6 +153,14 @@ public class OAuth2Credentials extends Credentials {
         }
       }
     }
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
   }
 
   // Must be called under lock
@@ -278,5 +286,29 @@ public class OAuth2Credentials extends Credentials {
 
   protected static <T> T getFromServiceLoader(Class<? extends T> clazz, T defaultInstance) {
     return Iterables.getFirst(ServiceLoader.load(clazz), defaultInstance);
+  }
+
+  public static class Builder {
+
+    private AccessToken accessToken;
+
+    public Builder setAccessToken(AccessToken token) {
+      this.accessToken = token;
+      return this;
+    }
+
+    public AccessToken getAccessToken() {
+      return accessToken;
+    }
+
+    public OAuth2Credentials build() {
+      return new OAuth2Credentials(accessToken);
+    }
+
+    protected Builder() {}
+
+    protected Builder(OAuth2Credentials credentials) {
+      this.accessToken = credentials.getAccessToken();
+    }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -101,41 +101,6 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
   private transient HttpTransportFactory transportFactory;
 
   /**
-   * Constructor with minimum identifying information.
-   *
-   * @param clientId Client ID of the service account from the console. May be null.
-   * @param clientEmail Client email address of the service account from the console.
-   * @param privateKey RSA private key object for the service account.
-   * @param privateKeyId Private key identifier for the service account. May be null.
-   * @param scopes Scope strings for the APIs to be called. May be null or an empty collection,
-   *        which results in a credential that must have createScoped called before use.
-   */
-  public ServiceAccountCredentials(
-      String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId,
-      Collection<String> scopes) {
-    this(clientId, clientEmail, privateKey, privateKeyId, scopes, null, null, null, null);
-  }
-
-  /**
-   * Constructor with minimum identifying information and custom HTTP transport.
-   *
-   * @param clientId Client ID of the service account from the console. May be null.
-   * @param clientEmail Client email address of the service account from the console.
-   * @param privateKey RSA private key object for the service account.
-   * @param privateKeyId Private key identifier for the service account. May be null.
-   * @param scopes Scope strings for the APIs to be called. May be null or an empty collection,
-   *        which results in a credential that must have createScoped called before use.
-   * @param transportFactory HTTP transport factory, creates the transport used to get access
-   *        tokens.
-   * @param tokenServerUri URI of the end point that provides tokens.
-   */
-  public ServiceAccountCredentials(
-      String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId,
-      Collection<String> scopes, HttpTransportFactory transportFactory, URI tokenServerUri) {
-    this(clientId, clientEmail, privateKey, privateKeyId, scopes, transportFactory, tokenServerUri, null, null);
-  }
-
-  /**
    * Constructor with minimum identifying information and custom HTTP transport.
    *
    * @param clientId Client ID of the service account from the console. May be null.
@@ -150,7 +115,7 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
    * @param serviceAccountUser Email of the user account to impersonate, if delegating domain-wide
    *        authority to the service account.
    */
-  ServiceAccountCredentials(
+  protected ServiceAccountCredentials(
       String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId,
       Collection<String> scopes, HttpTransportFactory transportFactory, URI tokenServerUri,
       String serviceAccountUser, String projectId) {
@@ -514,5 +479,128 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
           "Error signing service account access token request with private key.", e);
     }
     return assertion;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  public static class Builder extends GoogleCredentials.Builder {
+
+    private String clientId;
+    private String clientEmail;
+    private PrivateKey privateKey;
+    private String privateKeyId;
+    private String serviceAccountUser;
+    private String projectId;
+    private URI tokenServerUri;
+    private Collection<String> scopes;
+    private HttpTransportFactory transportFactory;
+
+    public ServiceAccountCredentials build() {
+      return new ServiceAccountCredentials(
+          clientId, clientEmail, privateKey, privateKeyId, scopes,
+          transportFactory, tokenServerUri, serviceAccountUser, projectId);
+    }
+
+    public Builder setClientId(String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    public Builder setClientEmail(String clientEmail) {
+      this.clientEmail = clientEmail;
+      return this;
+    }
+
+    public Builder setPrivateKey(PrivateKey privateKey) {
+      this.privateKey = privateKey;
+      return this;
+    }
+
+    public Builder setPrivateKeyId(String privateKeyId) {
+      this.privateKeyId = privateKeyId;
+      return this;
+    }
+
+    public Builder setScopes(Collection<String> scopes) {
+      this.scopes = scopes;
+      return this;
+    }
+
+    public Builder setServiceAccountUser(String serviceAccountUser) {
+      this.serviceAccountUser = serviceAccountUser;
+      return this;
+    }
+
+    public Builder setProjectId(String projectId) {
+      this.projectId = projectId;
+      return this;
+    }
+
+    public Builder setTokenServerUri(URI tokenServerUri) {
+      this.tokenServerUri = tokenServerUri;
+      return this;
+    }
+
+
+    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+      this.transportFactory = transportFactory;
+      return this;
+    }
+
+    public String getClientId() {
+      return clientId;
+    }
+
+    public String getClientEmail() {
+      return clientEmail;
+    }
+
+    public PrivateKey getPrivateKey() {
+      return privateKey;
+    }
+
+    public String getPrivateKeyId() {
+      return privateKeyId;
+    }
+
+    public Collection<String> getScopes() {
+      return scopes;
+    }
+
+    public String getServiceAccountUser() {
+      return serviceAccountUser;
+    }
+
+    public String getProjectId() {
+      return projectId;
+    }
+
+    public URI getTokenServerUri() {
+      return tokenServerUri;
+    }
+
+    public HttpTransportFactory getHttpTransportFactory() {
+      return transportFactory;
+    }
+
+    protected Builder() {}
+
+    protected Builder(ServiceAccountCredentials credentials) {
+      this.clientId = credentials.clientId;
+      this.clientEmail = credentials.clientEmail;
+      this.privateKey = credentials.privateKey;
+      this.privateKeyId = credentials.privateKeyId;
+      this.scopes = credentials.scopes;
+      this.transportFactory = credentials.transportFactory;
+      this.tokenServerUri = credentials.tokenServerUri;
+      this.serviceAccountUser = credentials.serviceAccountUser;
+      this.projectId = credentials.projectId;
+    }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -152,7 +152,8 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
    * @param serviceAccountUser Email of the user account to impersonate, if delegating domain-wide
    *        authority to the service account.
    */
-  protected ServiceAccountCredentials(
+  @Deprecated
+  public ServiceAccountCredentials(
       String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId,
       Collection<String> scopes, HttpTransportFactory transportFactory, URI tokenServerUri,
       String serviceAccountUser, String projectId) {

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -101,6 +101,43 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
   private transient HttpTransportFactory transportFactory;
 
   /**
+   * Constructor with minimum identifying information.
+   *
+   * @param clientId Client ID of the service account from the console. May be null.
+   * @param clientEmail Client email address of the service account from the console.
+   * @param privateKey RSA private key object for the service account.
+   * @param privateKeyId Private key identifier for the service account. May be null.
+   * @param scopes Scope strings for the APIs to be called. May be null or an empty collection,
+   *        which results in a credential that must have createScoped called before use.
+   */
+  @Deprecated
+  public ServiceAccountCredentials(
+      String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId,
+      Collection<String> scopes) {
+    this(clientId, clientEmail, privateKey, privateKeyId, scopes, null, null, null, null);
+  }
+
+  /**
+   * Constructor with minimum identifying information and custom HTTP transport.
+   *
+   * @param clientId Client ID of the service account from the console. May be null.
+   * @param clientEmail Client email address of the service account from the console.
+   * @param privateKey RSA private key object for the service account.
+   * @param privateKeyId Private key identifier for the service account. May be null.
+   * @param scopes Scope strings for the APIs to be called. May be null or an empty collection,
+   *        which results in a credential that must have createScoped called before use.
+   * @param transportFactory HTTP transport factory, creates the transport used to get access
+   *        tokens.
+   * @param tokenServerUri URI of the end point that provides tokens.
+   */
+  @Deprecated
+  public ServiceAccountCredentials(
+      String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId,
+      Collection<String> scopes, HttpTransportFactory transportFactory, URI tokenServerUri) {
+    this(clientId, clientEmail, privateKey, privateKeyId, scopes, transportFactory, tokenServerUri, null, null);
+  }
+
+  /**
    * Constructor with minimum identifying information and custom HTTP transport.
    *
    * @param clientId Client ID of the service account from the console. May be null.
@@ -501,10 +538,18 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
     private Collection<String> scopes;
     private HttpTransportFactory transportFactory;
 
-    public ServiceAccountCredentials build() {
-      return new ServiceAccountCredentials(
-          clientId, clientEmail, privateKey, privateKeyId, scopes,
-          transportFactory, tokenServerUri, serviceAccountUser, projectId);
+    protected Builder() {}
+
+    protected Builder(ServiceAccountCredentials credentials) {
+      this.clientId = credentials.clientId;
+      this.clientEmail = credentials.clientEmail;
+      this.privateKey = credentials.privateKey;
+      this.privateKeyId = credentials.privateKeyId;
+      this.scopes = credentials.scopes;
+      this.transportFactory = credentials.transportFactory;
+      this.tokenServerUri = credentials.tokenServerUri;
+      this.serviceAccountUser = credentials.serviceAccountUser;
+      this.projectId = credentials.projectId;
     }
 
     public Builder setClientId(String clientId) {
@@ -547,7 +592,6 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
       return this;
     }
 
-
     public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
       this.transportFactory = transportFactory;
       return this;
@@ -589,18 +633,10 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
       return transportFactory;
     }
 
-    protected Builder() {}
-
-    protected Builder(ServiceAccountCredentials credentials) {
-      this.clientId = credentials.clientId;
-      this.clientEmail = credentials.clientEmail;
-      this.privateKey = credentials.privateKey;
-      this.privateKeyId = credentials.privateKeyId;
-      this.scopes = credentials.scopes;
-      this.transportFactory = credentials.transportFactory;
-      this.tokenServerUri = credentials.tokenServerUri;
-      this.serviceAccountUser = credentials.serviceAccountUser;
-      this.projectId = credentials.projectId;
+    public ServiceAccountCredentials build() {
+      return new ServiceAccountCredentials(
+          clientId, clientEmail, privateKey, privateKeyId, scopes,
+          transportFactory, tokenServerUri, serviceAccountUser, projectId);
     }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -152,8 +152,7 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
    * @param serviceAccountUser Email of the user account to impersonate, if delegating domain-wide
    *        authority to the service account.
    */
-  @Deprecated
-  public ServiceAccountCredentials(
+  ServiceAccountCredentials(
       String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId,
       Collection<String> scopes, HttpTransportFactory transportFactory, URI tokenServerUri,
       String serviceAccountUser, String projectId) {

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -107,7 +107,8 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    * @param privateKeyId Private key identifier for the service account. May be null.
    * @param defaultAudience Audience to use if not provided by transport. May be null.
    */
-  protected ServiceAccountJwtAccessCredentials(String clientId, String clientEmail,
+  @Deprecated
+  public ServiceAccountJwtAccessCredentials(String clientId, String clientEmail,
       PrivateKey privateKey, String privateKeyId, URI defaultAudience) {
     this.clientId = clientId;
     this.clientEmail = Preconditions.checkNotNull(clientEmail);

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -85,6 +85,20 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   transient Clock clock = Clock.SYSTEM;
 
   /**
+   * Constructor with minimum identifying information.
+   *
+   * @param clientId Client ID of the service account from the console. May be null.
+   * @param clientEmail Client email address of the service account from the console.
+   * @param privateKey RSA private key object for the service account.
+   * @param privateKeyId Private key identifier for the service account. May be null.
+   */
+  @Deprecated
+  public ServiceAccountJwtAccessCredentials(
+      String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId) {
+    this(clientId, clientEmail, privateKey, privateKeyId, null);
+  }
+
+  /**
    * Constructor with full information.
    *
    * @param clientId Client ID of the service account from the console. May be null.
@@ -368,9 +382,14 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
     private String privateKeyId;
     private URI defaultAudience;
 
-    public ServiceAccountJwtAccessCredentials build() {
-      return new ServiceAccountJwtAccessCredentials(
-          clientId, clientEmail, privateKey, privateKeyId, defaultAudience);
+    protected Builder() {}
+
+    protected Builder(ServiceAccountJwtAccessCredentials credentials) {
+      this.clientId = credentials.clientId;
+      this.clientEmail = credentials.clientEmail;
+      this.privateKey = credentials.privateKey;
+      this.privateKeyId = credentials.privateKeyId;
+      this.defaultAudience = credentials.defaultAudience;
     }
 
     public Builder setClientId(String clientId) {
@@ -413,14 +432,9 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
       return defaultAudience;
     }
 
-    protected Builder() {}
-
-    protected Builder(ServiceAccountJwtAccessCredentials credentials) {
-      this.clientId = credentials.clientId;
-      this.clientEmail = credentials.clientEmail;
-      this.privateKey = credentials.privateKey;
-      this.privateKeyId = credentials.privateKeyId;
-      this.defaultAudience = credentials.defaultAudience;
+    public ServiceAccountJwtAccessCredentials build() {
+      return new ServiceAccountJwtAccessCredentials(
+          clientId, clientEmail, privateKey, privateKeyId, defaultAudience);
     }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -85,19 +85,6 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   transient Clock clock = Clock.SYSTEM;
 
   /**
-   * Constructor with minimum identifying information.
-   *
-   * @param clientId Client ID of the service account from the console. May be null.
-   * @param clientEmail Client email address of the service account from the console.
-   * @param privateKey RSA private key object for the service account.
-   * @param privateKeyId Private key identifier for the service account. May be null.
-   */
-  public ServiceAccountJwtAccessCredentials(
-      String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId) {
-    this(clientId, clientEmail, privateKey, privateKeyId, null);
-  }
-
-  /**
    * Constructor with full information.
    *
    * @param clientId Client ID of the service account from the console. May be null.
@@ -106,7 +93,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    * @param privateKeyId Private key identifier for the service account. May be null.
    * @param defaultAudience Audience to use if not provided by transport. May be null.
    */
-  public ServiceAccountJwtAccessCredentials(String clientId, String clientEmail,
+  protected ServiceAccountJwtAccessCredentials(String clientId, String clientEmail,
       PrivateKey privateKey, String privateKeyId, URI defaultAudience) {
     this.clientId = clientId;
     this.clientEmail = Preconditions.checkNotNull(clientEmail);
@@ -363,5 +350,77 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
     input.defaultReadObject();
     clock = Clock.SYSTEM;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  public static class Builder {
+
+    private String clientId;
+    private String clientEmail;
+    private PrivateKey privateKey;
+    private String privateKeyId;
+    private URI defaultAudience;
+
+    public ServiceAccountJwtAccessCredentials build() {
+      return new ServiceAccountJwtAccessCredentials(
+          clientId, clientEmail, privateKey, privateKeyId, defaultAudience);
+    }
+
+    public Builder setClientId(String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    public Builder setClientEmail(String clientEmail) {
+      this.clientEmail = clientEmail;
+      return this;
+    }
+
+    public Builder setPrivateKey(PrivateKey privateKey) {
+      this.privateKey = privateKey;
+      return this;
+    }
+
+    public Builder setPrivateKeyId(String privateKeyId) {
+      this.privateKeyId = privateKeyId;
+      return this;
+    }
+
+    public String getClientId() {
+      return clientId;
+    }
+
+    public String getClientEmail() {
+      return clientEmail;
+    }
+
+    public PrivateKey getPrivateKey() {
+      return privateKey;
+    }
+
+    public String getPrivateKeyId() {
+      return privateKeyId;
+    }
+
+    public URI getDefaultAudience() {
+      return defaultAudience;
+    }
+
+    protected Builder() {}
+
+    protected Builder(ServiceAccountJwtAccessCredentials credentials) {
+      this.clientId = credentials.clientId;
+      this.clientEmail = credentials.clientEmail;
+      this.privateKey = credentials.privateKey;
+      this.privateKeyId = credentials.privateKeyId;
+      this.defaultAudience = credentials.defaultAudience;
+    }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -70,7 +70,33 @@ public class UserAuthorizer {
   private final URI userAuthUri;
 
   /**
-   * Constructor
+   * Constructor with minimal parameters.
+   *
+   * @param clientId Client ID to identify the OAuth2 consent prompt.
+   * @param scopes OAUth2 scopes defining the user consent.
+   * @param tokenStore Implementation of component for long term storage of tokens.
+   */
+  @Deprecated
+  public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore) {
+    this(clientId, scopes, tokenStore, null, null, null, null);
+  }
+
+  /**
+   * Constructor with common parameters.
+   *
+   * @param clientId Client ID to identify the OAuth2 consent prompt.
+   * @param scopes OAUth2 scopes defining the user consent.
+   * @param tokenStore Implementation of component for long term storage of tokens.
+   * @param callbackUri URI for implementation of the OAuth2 web callback.
+   */
+  @Deprecated
+  public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore,
+                        URI callbackUri) {
+    this(clientId, scopes, tokenStore, callbackUri, null, null, null);
+  }
+
+  /**
+   * Constructor with all parameters.
    *
    * @param clientId Client ID to identify the OAuth2 consent prompt.
    * @param scopes OAUth2 scopes defining the user consent.
@@ -81,8 +107,9 @@ public class UserAuthorizer {
    * @param tokenServerUri URI of the end point that provides tokens.
    * @param userAuthUri URI of the Web UI for user consent.
    */
-  protected UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore,
-      URI callbackUri, HttpTransportFactory transportFactory, URI tokenServerUri, URI userAuthUri) {
+  @Deprecated
+  public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore,
+                        URI callbackUri, HttpTransportFactory transportFactory, URI tokenServerUri, URI userAuthUri) {
     this.clientId = Preconditions.checkNotNull(clientId);
     this.scopes = ImmutableList.copyOf(Preconditions.checkNotNull(scopes));
     this.callbackUri = (callbackUri == null) ? DEFAULT_CALLBACK_URI : callbackUri;
@@ -92,6 +119,7 @@ public class UserAuthorizer {
     this.userAuthUri = (userAuthUri == null) ? OAuth2Utils.USER_AUTH_URI : userAuthUri;
     this.tokenStore = tokenStore;
   }
+
 
   /**
    * Returns the Client ID user to identify the OAuth2 consent prompt.
@@ -384,9 +412,16 @@ public class UserAuthorizer {
     private Collection<String> scopes;
     private HttpTransportFactory transportFactory;
 
-    public UserAuthorizer build() {
-      return new UserAuthorizer(clientId, scopes, tokenStore,
-          callbackUri, transportFactory, tokenServerUri, userAuthUri);
+    protected Builder() {}
+
+    protected Builder(UserAuthorizer authorizer) {
+      this.clientId = authorizer.clientId;
+      this.scopes = authorizer.scopes;
+      this.transportFactory = authorizer.transportFactory;
+      this.tokenServerUri = authorizer.tokenServerUri;
+      this.tokenStore = authorizer.tokenStore;
+      this.callbackUri = authorizer.callbackUri;
+      this.userAuthUri = authorizer.userAuthUri;
     }
 
     public Builder setClientId(ClientId clientId) {
@@ -452,17 +487,9 @@ public class UserAuthorizer {
       return transportFactory;
     }
 
-    protected Builder() {
-    }
-
-    protected Builder(UserAuthorizer authorizer) {
-      this.clientId = authorizer.clientId;
-      this.scopes = authorizer.scopes;
-      this.transportFactory = authorizer.transportFactory;
-      this.tokenServerUri = authorizer.tokenServerUri;
-      this.tokenStore = authorizer.tokenStore;
-      this.callbackUri = authorizer.callbackUri;
-      this.userAuthUri = authorizer.userAuthUri;
+    public UserAuthorizer build() {
+      return new UserAuthorizer(clientId, scopes, tokenStore,
+          callbackUri, transportFactory, tokenServerUri, userAuthUri);
     }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -70,31 +70,7 @@ public class UserAuthorizer {
   private final URI userAuthUri;
 
   /**
-   * Constructor with minimal parameters.
-   *
-   * @param clientId Client ID to identify the OAuth2 consent prompt.
-   * @param scopes OAUth2 scopes defining the user consent.
-   * @param tokenStore Implementation of component for long term storage of tokens.
-   */
-  public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore) {
-    this(clientId, scopes, tokenStore, null, null, null, null);
-  }
-
-  /**
-   * Constructor with common parameters.
-   *
-   * @param clientId Client ID to identify the OAuth2 consent prompt.
-   * @param scopes OAUth2 scopes defining the user consent.
-   * @param tokenStore Implementation of component for long term storage of tokens.
-   * @param callbackUri URI for implementation of the OAuth2 web callback.
-   */
-  public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore,
-      URI callbackUri) {
-    this(clientId, scopes, tokenStore, callbackUri, null, null, null);
-  }
-
-  /**
-   * Constructor with all parameters.
+   * Constructor
    *
    * @param clientId Client ID to identify the OAuth2 consent prompt.
    * @param scopes OAUth2 scopes defining the user consent.
@@ -105,7 +81,7 @@ public class UserAuthorizer {
    * @param tokenServerUri URI of the end point that provides tokens.
    * @param userAuthUri URI of the Web UI for user consent.
    */
-  public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore,
+  protected UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore,
       URI callbackUri, HttpTransportFactory transportFactory, URI tokenServerUri, URI userAuthUri) {
     this.clientId = Preconditions.checkNotNull(clientId);
     this.scopes = ImmutableList.copyOf(Preconditions.checkNotNull(scopes));
@@ -387,6 +363,106 @@ public class UserAuthorizer {
     public void onChanged(OAuth2Credentials credentials) throws IOException {
       UserCredentials userCredentials = (UserCredentials)credentials;
       storeCredentials(userId, userCredentials);
+    }
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  public static class Builder {
+
+    private ClientId clientId;
+    private TokenStore tokenStore;
+    private URI callbackUri;
+    private URI tokenServerUri;
+    private URI userAuthUri;
+    private Collection<String> scopes;
+    private HttpTransportFactory transportFactory;
+
+    public UserAuthorizer build() {
+      return new UserAuthorizer(clientId, scopes, tokenStore,
+          callbackUri, transportFactory, tokenServerUri, userAuthUri);
+    }
+
+    public Builder setClientId(ClientId clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    public Builder setTokenStore(TokenStore tokenStore) {
+      this.tokenStore = tokenStore;
+      return this;
+    }
+
+    public Builder setScopes(Collection<String> scopes) {
+      this.scopes = scopes;
+      return this;
+    }
+
+    public Builder setTokenServerUri(URI tokenServerUri) {
+      this.tokenServerUri = tokenServerUri;
+      return this;
+    }
+
+    public Builder setCallbackUri(URI callbackUri) {
+      this.callbackUri = callbackUri;
+      return this;
+    }
+
+    public Builder setUserAuthUri(URI userAuthUri) {
+      this.userAuthUri = userAuthUri;
+      return this;
+    }
+
+    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+      this.transportFactory = transportFactory;
+      return this;
+    }
+
+    public ClientId getClientId() {
+      return clientId;
+    }
+
+    public TokenStore getTokenStore() {
+      return tokenStore;
+    }
+
+    public Collection<String> getScopes() {
+      return scopes;
+    }
+
+    public URI getTokenServerUri() {
+      return tokenServerUri;
+    }
+
+    public URI getCallbackUri() {
+      return callbackUri;
+    }
+
+    public URI getUserAuthUri() {
+      return userAuthUri;
+    }
+
+    public HttpTransportFactory getHttpTransportFactory() {
+      return transportFactory;
+    }
+
+    protected Builder() {
+    }
+
+    protected Builder(UserAuthorizer authorizer) {
+      this.clientId = authorizer.clientId;
+      this.scopes = authorizer.scopes;
+      this.transportFactory = authorizer.transportFactory;
+      this.tokenServerUri = authorizer.tokenServerUri;
+      this.tokenStore = authorizer.tokenStore;
+      this.callbackUri = authorizer.callbackUri;
+      this.userAuthUri = authorizer.userAuthUri;
     }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -90,8 +90,7 @@ public class UserAuthorizer {
    * @param callbackUri URI for implementation of the OAuth2 web callback.
    */
   @Deprecated
-  public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore,
-                        URI callbackUri) {
+  public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore, URI callbackUri) {
     this(clientId, scopes, tokenStore, callbackUri, null, null, null);
   }
 

--- a/oauth2_http/javatests/com/google/auth/http/HttpCredentialsAdapterTest.java
+++ b/oauth2_http/javatests/com/google/auth/http/HttpCredentialsAdapterTest.java
@@ -67,8 +67,14 @@ public class HttpCredentialsAdapterTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken);
-    OAuth2Credentials credentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, null, transportFactory, null);
+
+    OAuth2Credentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setHttpTransportFactory(transportFactory)
+        .build();
+
     HttpCredentialsAdapter adapter = new HttpCredentialsAdapter(credentials);
     HttpRequestFactory requestFactory = transportFactory.transport.createRequestFactory();
     HttpRequest request = requestFactory.buildGetRequest(new GenericUrl("http://foo"));
@@ -90,8 +96,13 @@ public class HttpCredentialsAdapterTest {
     tokenServerTransportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     tokenServerTransportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken);
 
-    OAuth2Credentials credentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, null, tokenServerTransportFactory, null);
+    OAuth2Credentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setHttpTransportFactory(tokenServerTransportFactory)
+        .build();
+
     credentials.refresh();
     HttpCredentialsAdapter adapter = new HttpCredentialsAdapter(credentials);
 
@@ -120,8 +131,14 @@ public class HttpCredentialsAdapterTest {
         new MockTokenServerTransportFactory();
     tokenServerTransportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     tokenServerTransportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken);
-    OAuth2Credentials credentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, null, tokenServerTransportFactory, null);
+
+    OAuth2Credentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setHttpTransportFactory(tokenServerTransportFactory)
+        .build();
+
     HttpCredentialsAdapter adapter = new HttpCredentialsAdapter(credentials);
     HttpRequestFactory requestFactory =
         tokenServerTransportFactory.transport.createRequestFactory();

--- a/oauth2_http/javatests/com/google/auth/oauth2/ClientIdTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ClientIdTest.java
@@ -55,7 +55,10 @@ public class ClientIdTest {
 
   @Test
   public void constructor() {
-    ClientId clientId = new ClientId(CLIENT_ID, CLIENT_SECRET);
+    ClientId clientId = ClientId.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .build();
 
     assertEquals(CLIENT_ID, clientId.getClientId());
     assertEquals(CLIENT_SECRET, clientId.getClientSecret());
@@ -63,13 +66,16 @@ public class ClientIdTest {
 
   @Test(expected = NullPointerException.class)
   public void constructor_nullClientId_throws() {
-    new ClientId(null, CLIENT_SECRET);
+    ClientId clientId = ClientId.newBuilder()
+        .setClientSecret(CLIENT_SECRET)
+        .build();
   }
 
   @Test
   public void constructor_nullClientSecret() {
-    ClientId clientId = new ClientId(CLIENT_ID, null);
-
+    ClientId clientId = ClientId.newBuilder()
+        .setClientId(CLIENT_ID)
+        .build();
     assertEquals(CLIENT_ID, clientId.getClientId());
     assertNull(clientId.getClientSecret());
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/CloudShellCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/CloudShellCredentialsTest.java
@@ -80,8 +80,10 @@ public class CloudShellCredentialsTest extends BaseSerializationTest {
       };
       Thread serverThread = new Thread(serverTask);
       serverThread.start();
-      
-      GoogleCredentials creds = new CloudShellCredentials(authSocket.getLocalPort());
+
+      GoogleCredentials creds = CloudShellCredentials.newBuilder()
+          .setAuthPort(authSocket.getLocalPort())
+          .build();
       assertEquals("token", creds.refreshAccessToken().getTokenValue());
     } finally {
       authSocket.close();
@@ -90,16 +92,24 @@ public class CloudShellCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void equals_true() throws IOException {
-    GoogleCredentials credentials = new CloudShellCredentials(42);
-    GoogleCredentials otherCredentials = new CloudShellCredentials(42);
+    GoogleCredentials credentials = CloudShellCredentials.newBuilder()
+        .setAuthPort(42)
+        .build();
+    GoogleCredentials otherCredentials = CloudShellCredentials.newBuilder()
+        .setAuthPort(42)
+        .build();
     assertTrue(credentials.equals(otherCredentials));
     assertTrue(otherCredentials.equals(credentials));
   }
 
   @Test
   public void equals_false_authPort() throws IOException {
-    GoogleCredentials credentials = new CloudShellCredentials(42);
-    GoogleCredentials otherCredentials = new CloudShellCredentials(43);
+    GoogleCredentials credentials = CloudShellCredentials.newBuilder()
+        .setAuthPort(42)
+        .build();
+    GoogleCredentials otherCredentials = CloudShellCredentials.newBuilder()
+        .setAuthPort(43)
+        .build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -107,20 +117,28 @@ public class CloudShellCredentialsTest extends BaseSerializationTest {
   @Test
   public void toString_containsFields() throws IOException {
     String expectedToString = String.format("CloudShellCredentials{authPort=%d}", 42);
-    GoogleCredentials credentials = new CloudShellCredentials(42);
+    GoogleCredentials credentials = CloudShellCredentials.newBuilder()
+        .setAuthPort(42)
+        .build();
     assertEquals(expectedToString, credentials.toString());
   }
 
   @Test
   public void hashCode_equals() throws IOException {
-    GoogleCredentials credentials = new CloudShellCredentials(42);
-    GoogleCredentials otherCredentials = new CloudShellCredentials(42);
+    GoogleCredentials credentials = CloudShellCredentials.newBuilder()
+        .setAuthPort(42)
+        .build();
+    GoogleCredentials otherCredentials = CloudShellCredentials.newBuilder()
+        .setAuthPort(42)
+        .build();
     assertEquals(credentials.hashCode(), otherCredentials.hashCode());
   }
 
   @Test
   public void serialize() throws IOException, ClassNotFoundException {
-    GoogleCredentials credentials = new CloudShellCredentials(42);
+    GoogleCredentials credentials = CloudShellCredentials.newBuilder()
+        .setAuthPort(42)
+        .build();
     GoogleCredentials deserializedCredentials = serializeAndDeserialize(credentials);
     assertEquals(credentials, deserializedCredentials);
     assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -76,8 +76,8 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     final String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     transportFactory.transport.setAccessToken(accessToken);
-    ComputeEngineCredentials credentials = new ComputeEngineCredentials(transportFactory);
-
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, accessToken);
@@ -89,8 +89,8 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     transportFactory.transport.setAccessToken(accessToken);
     transportFactory.transport.setTokenRequestStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
-    ComputeEngineCredentials credentials = new ComputeEngineCredentials(transportFactory);
-
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     try {
       credentials.getRequestMetadata(CALL_URI);
       fail("Expected error refreshing token.");
@@ -107,8 +107,8 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     transportFactory.transport.setAccessToken(accessToken);
     transportFactory.transport.setTokenRequestStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
-    ComputeEngineCredentials credentials = new ComputeEngineCredentials(transportFactory);
-
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     try {
       credentials.getRequestMetadata(CALL_URI);
       fail("Expected error refreshing token.");
@@ -133,8 +133,10 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockHttpTransportFactory httpTransportFactory = new MockHttpTransportFactory();
     MockMetadataServerTransportFactory serverTransportFactory =
         new MockMetadataServerTransportFactory();
-    ComputeEngineCredentials credentials = new ComputeEngineCredentials(serverTransportFactory);
-    ComputeEngineCredentials otherCredentials = new ComputeEngineCredentials(httpTransportFactory);
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();
+    ComputeEngineCredentials otherCredentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(httpTransportFactory).build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -146,7 +148,8 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     String expectedToString =
         String.format("ComputeEngineCredentials{transportFactoryClassName=%s}",
             MockMetadataServerTransportFactory.class.getName());
-    ComputeEngineCredentials credentials = new ComputeEngineCredentials(serverTransportFactory);
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();
     assertEquals(expectedToString, credentials.toString());
   }
 
@@ -154,8 +157,8 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
   public void hashCode_equals() throws IOException {
     MockMetadataServerTransportFactory serverTransportFactory =
         new MockMetadataServerTransportFactory();
-    ComputeEngineCredentials credentials = new ComputeEngineCredentials(serverTransportFactory);
-    ComputeEngineCredentials otherCredentials =
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();    ComputeEngineCredentials otherCredentials =
         new ComputeEngineCredentials(serverTransportFactory);
     assertEquals(credentials.hashCode(), otherCredentials.hashCode());
   }
@@ -164,13 +167,14 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
   public void serialize() throws IOException, ClassNotFoundException {
     MockMetadataServerTransportFactory serverTransportFactory =
         new MockMetadataServerTransportFactory();
-    ComputeEngineCredentials credentials = new ComputeEngineCredentials(serverTransportFactory);
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();
     GoogleCredentials deserializedCredentials = serializeAndDeserialize(credentials);
     assertEquals(credentials, deserializedCredentials);
     assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());
     assertEquals(credentials.toString(), deserializedCredentials.toString());
     assertSame(deserializedCredentials.clock, Clock.SYSTEM);
-    credentials = new ComputeEngineCredentials();
+    credentials = ComputeEngineCredentials.newBuilder().build();
     deserializedCredentials = serializeAndDeserialize(credentials);
     assertEquals(credentials, deserializedCredentials);
     assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());

--- a/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
@@ -70,26 +70,39 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
 
   @Test
   public void constructor_storesAccessToken() {
-    OAuth2Credentials credentials = new OAuth2Credentials(new AccessToken(ACCESS_TOKEN, null));
-
+    OAuth2Credentials credentials = OAuth2Credentials.newBuilder()
+        .setAccessToken(new AccessToken(ACCESS_TOKEN, null))
+        .build();
     assertEquals(credentials.getAccessToken().getTokenValue(), ACCESS_TOKEN);
   }
 
   @Test
   public void getAuthenticationType_returnsOAuth2() {
-    OAuth2Credentials credentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN);
+    OAuth2Credentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .build();
     assertEquals(credentials.getAuthenticationType(), "OAuth2");
   }
 
   @Test
   public void hasRequestMetadata_returnsTrue() {
-    OAuth2Credentials credentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN);
+    OAuth2Credentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .build();
     assertTrue(credentials.hasRequestMetadata());
   }
 
   @Test
   public void hasRequestMetadataOnly_returnsTrue() {
-    OAuth2Credentials credentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN);
+    OAuth2Credentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .build();
     assertTrue(credentials.hasRequestMetadata());
   }
 
@@ -100,8 +113,12 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken1);
-    OAuth2Credentials userCredentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, null, transportFactory, null);
+    OAuth2Credentials userCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setHttpTransportFactory(transportFactory)
+        .build();
     // Use a fixed clock so tokens don't expire
     userCredentials.clock = new TestClock();
     TestChangeListener listener = new TestChangeListener();
@@ -134,8 +151,12 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken1);
     TestClock clock = new TestClock();
-    OAuth2Credentials credentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, null, transportFactory, null);
+    OAuth2Credentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setHttpTransportFactory(transportFactory)
+        .build();
     credentials.clock = clock;
 
     // Verify getting the first token
@@ -183,8 +204,12 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken1);
     TestClock clock = new TestClock();
-    OAuth2Credentials credentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, null, transportFactory, null);
+    OAuth2Credentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setHttpTransportFactory(transportFactory)
+        .build();
     credentials.clock = clock;
 
     MockExecutor executor = new MockExecutor();
@@ -247,8 +272,12 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken1);
     TestClock clock = new TestClock();
-    OAuth2Credentials credentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, null, transportFactory, null);
+    OAuth2Credentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setHttpTransportFactory(transportFactory)
+        .build();
     credentials.clock = clock;
 
     MockExecutor executor = new MockExecutor();
@@ -272,7 +301,9 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
 
   @Test
   public void getRequestMetadata_temporaryToken_hasToken() throws IOException {
-    OAuth2Credentials credentials = new OAuth2Credentials(new AccessToken(ACCESS_TOKEN, null));
+    OAuth2Credentials credentials = OAuth2Credentials.newBuilder()
+        .setAccessToken(new AccessToken(ACCESS_TOKEN, null))
+        .build();
 
     // Verify getting the first token
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -286,8 +317,12 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken1);
-    OAuth2Credentials userCredentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, null, transportFactory, null);
+    OAuth2Credentials userCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setHttpTransportFactory(transportFactory)
+        .build();
     // Use a fixed clock so tokens don't exire
     userCredentials.clock = new TestClock();
 
@@ -312,15 +347,21 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
 
   @Test(expected = IllegalStateException.class)
   public void refresh_temporaryToken_throws() throws IOException {
-    OAuth2Credentials credentials = new OAuth2Credentials(new AccessToken(ACCESS_TOKEN, null));
+    OAuth2Credentials credentials = OAuth2Credentials.newBuilder()
+        .setAccessToken(new AccessToken(ACCESS_TOKEN, null))
+        .build();
     credentials.refresh();
   }
 
   @Test
   public void equals_true() throws IOException {
     final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    OAuth2Credentials credentials = new OAuth2Credentials(new AccessToken(accessToken1, null));
-    OAuth2Credentials otherCredentials = new OAuth2Credentials(new AccessToken(accessToken1, null));
+    OAuth2Credentials credentials = OAuth2Credentials.newBuilder()
+        .setAccessToken(new AccessToken(accessToken1, null))
+        .build();
+    OAuth2Credentials otherCredentials = OAuth2Credentials.newBuilder()
+        .setAccessToken(new AccessToken(accessToken1, null))
+        .build();
     assertTrue(credentials.equals(otherCredentials));
     assertTrue(otherCredentials.equals(credentials));
   }
@@ -329,8 +370,12 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
   public void equals_false_accessToken() throws IOException {
     final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
     final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
-    OAuth2Credentials credentials = new OAuth2Credentials(new AccessToken(accessToken1, null));
-    OAuth2Credentials otherCredentials = new OAuth2Credentials(new AccessToken(accessToken2, null));
+    OAuth2Credentials credentials = OAuth2Credentials.newBuilder()
+        .setAccessToken(new AccessToken(accessToken1, null))
+        .build();
+    OAuth2Credentials otherCredentials = OAuth2Credentials.newBuilder()
+        .setAccessToken(new AccessToken(accessToken2, null))
+        .build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -338,7 +383,9 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
   @Test
   public void toString_containsFields() throws IOException {
     AccessToken accessToken = new AccessToken("1/MkSJoj1xsli0AccessToken_NKPY2", null);
-    OAuth2Credentials credentials = new OAuth2Credentials(accessToken);
+    OAuth2Credentials credentials = OAuth2Credentials.newBuilder()
+        .setAccessToken(accessToken)
+        .build();
     String expectedToString =
         String.format("OAuth2Credentials{requestMetadata=%s, temporaryAccess=%s}",
             ImmutableMap.of(AuthHttpConstants.AUTHORIZATION,
@@ -350,7 +397,9 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
   @Test
   public void hashCode_equals() throws IOException {
     final String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    OAuth2Credentials credentials = new OAuth2Credentials(new AccessToken(accessToken, null));
+    OAuth2Credentials credentials = OAuth2Credentials.newBuilder()
+        .setAccessToken(new AccessToken(accessToken, null))
+        .build();
     OAuth2Credentials otherCredentials = new OAuth2Credentials(new AccessToken(accessToken, null));
     assertEquals(credentials.hashCode(), otherCredentials.hashCode());
   }
@@ -358,8 +407,9 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
   @Test
   public void serialize() throws IOException, ClassNotFoundException {
     final String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    OAuth2Credentials credentials = new OAuth2Credentials(new AccessToken(accessToken, null));
-    OAuth2Credentials deserializedCredentials = serializeAndDeserialize(credentials);
+    OAuth2Credentials credentials = OAuth2Credentials.newBuilder()
+        .setAccessToken(new AccessToken(accessToken, null))
+        .build();    OAuth2Credentials deserializedCredentials = serializeAndDeserialize(credentials);
     assertEquals(credentials, deserializedCredentials);
     assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());
     assertEquals(credentials.toString(), deserializedCredentials.toString());

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -109,8 +109,15 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   @Test
   public void createdScoped_clones() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    GoogleCredentials credentials = new ServiceAccountCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, SCOPES, null, null, SERVICE_ACCOUNT_USER, PROJECT_ID);
+    GoogleCredentials credentials = ServiceAccountCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setScopes(SCOPES)
+        .setServiceAccountUser(SERVICE_ACCOUNT_USER)
+        .setProjectId(PROJECT_ID)
+        .build();
     List<String> newScopes = Arrays.asList("scope1", "scope2");
 
     ServiceAccountCredentials newCredentials =
@@ -130,8 +137,15 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     @Test
   public void createdDelegated_clones() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    GoogleCredentials credentials = new ServiceAccountCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, SCOPES, null, null, SERVICE_ACCOUNT_USER, PROJECT_ID);
+    ServiceAccountCredentials credentials = ServiceAccountCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setScopes(SCOPES)
+        .setServiceAccountUser(SERVICE_ACCOUNT_USER)
+        .setProjectId(PROJECT_ID)
+        .build();
     String newServiceAccountUser = "stranger@other.org";
 
     ServiceAccountCredentials newCredentials =
@@ -152,8 +166,15 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void createAssertion_correct() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     List<String> scopes = Arrays.asList("scope1", "scope2");
-    ServiceAccountCredentials credentials = new ServiceAccountCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, scopes, null, null, SERVICE_ACCOUNT_USER, PROJECT_ID);
+    ServiceAccountCredentials credentials = ServiceAccountCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setScopes(scopes)
+        .setServiceAccountUser(SERVICE_ACCOUNT_USER)
+        .setProjectId(PROJECT_ID)
+        .build();
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -95,8 +95,12 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test 
   public void constructor_allParameters_constructs() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountJwtAccessCredentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .build();
     
     assertEquals(SA_CLIENT_ID, credentials.getClientId());
     assertEquals(SA_CLIENT_EMAIL, credentials.getClientEmail());
@@ -107,21 +111,30 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test 
   public void constructor_noClientId_constructs() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    new ServiceAccountJwtAccessCredentials(null, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID);    
-  }
+    ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .build();  }
 
   @Test 
   public void constructor_noPrivateKeyId_constructs() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    new ServiceAccountJwtAccessCredentials(SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, null);    
-  }
+    ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .build();  }
 
   @Test 
   public void constructor_noEmail_throws() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     try {
-          new ServiceAccountJwtAccessCredentials(SA_CLIENT_ID, null, privateKey, SA_PRIVATE_KEY_ID);
-      fail("exception expected");
+      ServiceAccountJwtAccessCredentials.newBuilder()
+          .setClientId(SA_CLIENT_ID)
+          .setPrivateKey(privateKey)
+          .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+          .build();      fail("exception expected");
     } catch (NullPointerException e) {
       // Expected
     }
@@ -130,8 +143,11 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test 
   public void constructor_noPrivateKey_throws() {
     try {
-      new ServiceAccountJwtAccessCredentials(
-          SA_CLIENT_ID, SA_CLIENT_EMAIL, null , SA_PRIVATE_KEY_ID);
+      ServiceAccountJwtAccessCredentials.newBuilder()
+          .setClientId(SA_CLIENT_ID)
+          .setClientEmail(SA_CLIENT_EMAIL)
+          .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+          .build();
       fail("exception expected");
     } catch (NullPointerException e) {
       // Expected
@@ -162,8 +178,12 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void getRequestMetadata_blocking_hasJwtAccess() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    Credentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
@@ -184,8 +204,12 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void getRequestMetadata_blocking_noURI_throws() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    Credentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .build();
 
     try {
       credentials.getRequestMetadata();
@@ -198,8 +222,12 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void getRequestMetadata_async_hasJwtAccess() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    Credentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .build();
     MockExecutor executor = new MockExecutor();
     MockRequestMetadataCallback callback = new MockRequestMetadataCallback();
 
@@ -226,8 +254,12 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void getRequestMetadata_async_noURI_exception() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    Credentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .build();
     MockExecutor executor = new MockExecutor();
     MockRequestMetadataCallback callback = new MockRequestMetadataCallback();
 
@@ -239,8 +271,12 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void getAccount_sameAs() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountJwtAccessCredentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .build();
     assertEquals(SA_CLIENT_EMAIL, credentials.getAccount());
   }
 
@@ -249,8 +285,12 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
       throws IOException, NoSuchAlgorithmException, InvalidKeyException, SignatureException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     byte[] toSign = {0xD, 0xE, 0xA, 0xD};
-    ServiceAccountJwtAccessCredentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .build();
     byte[] signedBytes = credentials.sign(toSign);
     Signature signature = Signature.getInstance(OAuth2Utils.SIGNATURE_ALGORITHM);
     signature.initSign(credentials.getPrivateKey());

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
@@ -75,25 +75,39 @@ public class UserCredentialsTest extends BaseSerializationTest {
 
   @Test(expected = IllegalStateException.class)
   public void constructor_accessAndRefreshTokenNull_throws() {
-    new UserCredentials(CLIENT_ID, CLIENT_SECRET, null, null);
+    UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .build();
   }
 
   @Test
   public void constructor_storesRefreshToken() {
-    UserCredentials credentials =
-        new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, null);
+    UserCredentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .build();
     assertEquals(REFRESH_TOKEN, credentials.getRefreshToken());
   }
 
   @Test
   public void createScoped_same() {
-    UserCredentials userCredentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN);
+    UserCredentials userCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .build();
     assertSame(userCredentials, userCredentials.createScoped(SCOPES));
   }
 
   @Test
   public void createScopedRequired_false() {
-    UserCredentials userCredentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN);
+    UserCredentials userCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .build();
     assertFalse(userCredentials.createScopedRequired());
   }
 
@@ -115,8 +129,12 @@ public class UserCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, null);
-    OAuth2Credentials userCredentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, null, accessToken, transportFactory, null);
+    UserCredentials userCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(transportFactory)
+        .build();
 
     Map<String, List<String>> metadata = userCredentials.getRequestMetadata(CALL_URI);
 
@@ -128,8 +146,12 @@ public class UserCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, null);
-    OAuth2Credentials userCredentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, null, accessToken, transportFactory, null);
+    UserCredentials userCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(transportFactory)
+        .build();
 
     try {
       userCredentials.refresh();
@@ -144,8 +166,12 @@ public class UserCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
-    OAuth2Credentials userCredentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, null, transportFactory, null);
+    UserCredentials userCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setHttpTransportFactory(transportFactory)
+        .build();
 
     Map<String, List<String>> metadata = userCredentials.getRequestMetadata(CALL_URI);
 
@@ -159,8 +185,13 @@ public class UserCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
     transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
     transportFactory.transport.setTokenServerUri(TOKEN_SERVER);
-    OAuth2Credentials userCredentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, null, transportFactory, TOKEN_SERVER);
+    UserCredentials userCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setHttpTransportFactory(transportFactory)
+        .setTokenServerUri(TOKEN_SERVER)
+        .build();
 
     Map<String, List<String>> metadata = userCredentials.getRequestMetadata(CALL_URI);
 
@@ -172,10 +203,22 @@ public class UserCredentialsTest extends BaseSerializationTest {
     final URI tokenServer = URI.create("https://foo.com/bar");
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, null);
-    OAuth2Credentials credentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, accessToken, transportFactory, tokenServer);
-    OAuth2Credentials otherCredentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, accessToken, transportFactory, tokenServer);
+    UserCredentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(transportFactory)
+        .setTokenServerUri(tokenServer)
+        .build();
+    UserCredentials otherCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(transportFactory)
+        .setTokenServerUri(tokenServer)
+        .build();
     assertTrue(credentials.equals(otherCredentials));
     assertTrue(otherCredentials.equals(credentials));
   }
@@ -185,10 +228,22 @@ public class UserCredentialsTest extends BaseSerializationTest {
     final URI tokenServer1 = URI.create("https://foo1.com/bar");
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, null);
     MockHttpTransportFactory httpTransportFactory = new MockHttpTransportFactory();
-    OAuth2Credentials credentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN,
-        accessToken, httpTransportFactory, tokenServer1);
-    OAuth2Credentials otherCredentials = new UserCredentials("otherClientId", CLIENT_SECRET,
-        REFRESH_TOKEN, accessToken, httpTransportFactory, tokenServer1);
+    UserCredentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(httpTransportFactory)
+        .setTokenServerUri(tokenServer1)
+        .build();
+    UserCredentials otherCredentials = UserCredentials.newBuilder()
+        .setClientId("other client id")
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(httpTransportFactory)
+        .setTokenServerUri(tokenServer1)
+        .build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -198,10 +253,22 @@ public class UserCredentialsTest extends BaseSerializationTest {
     final URI tokenServer1 = URI.create("https://foo1.com/bar");
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, null);
     MockHttpTransportFactory httpTransportFactory = new MockHttpTransportFactory();
-    OAuth2Credentials credentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN,
-        accessToken, httpTransportFactory, tokenServer1);
-    OAuth2Credentials otherCredentials = new UserCredentials(CLIENT_ID, "otherClientSecret",
-        REFRESH_TOKEN, accessToken, httpTransportFactory, tokenServer1);
+    UserCredentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(httpTransportFactory)
+        .setTokenServerUri(tokenServer1)
+        .build();
+    UserCredentials otherCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret("other client secret")
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(httpTransportFactory)
+        .setTokenServerUri(tokenServer1)
+        .build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -225,10 +292,22 @@ public class UserCredentialsTest extends BaseSerializationTest {
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, null);
     AccessToken otherAccessToken = new AccessToken("otherAccessToken", null);
     MockHttpTransportFactory httpTransportFactory = new MockHttpTransportFactory();
-    OAuth2Credentials credentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN,
-        accessToken, httpTransportFactory, tokenServer1);
-    OAuth2Credentials otherCredentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET,
-        REFRESH_TOKEN, otherAccessToken, httpTransportFactory, tokenServer1);
+    UserCredentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(httpTransportFactory)
+        .setTokenServerUri(tokenServer1)
+        .build();
+    UserCredentials otherCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(otherAccessToken)
+        .setHttpTransportFactory(httpTransportFactory)
+        .setTokenServerUri(tokenServer1)
+        .build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -239,10 +318,22 @@ public class UserCredentialsTest extends BaseSerializationTest {
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, null);
     MockHttpTransportFactory httpTransportFactory = new MockHttpTransportFactory();
     MockTokenServerTransportFactory serverTransportFactory = new MockTokenServerTransportFactory();
-    OAuth2Credentials credentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN,
-        accessToken, httpTransportFactory, tokenServer1);
-    OAuth2Credentials otherCredentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET,
-        REFRESH_TOKEN, accessToken, serverTransportFactory, tokenServer1);
+    UserCredentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(httpTransportFactory)
+        .setTokenServerUri(tokenServer1)
+        .build();
+    UserCredentials otherCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(serverTransportFactory)
+        .setTokenServerUri(tokenServer1)
+        .build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -253,10 +344,22 @@ public class UserCredentialsTest extends BaseSerializationTest {
     final URI tokenServer2 = URI.create("https://foo2.com/bar");
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, null);
     MockHttpTransportFactory httpTransportFactory = new MockHttpTransportFactory();
-    OAuth2Credentials credentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN,
-        accessToken, httpTransportFactory, tokenServer1);
-    OAuth2Credentials otherCredentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET,
-        REFRESH_TOKEN, accessToken, httpTransportFactory, tokenServer2);
+    UserCredentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(httpTransportFactory)
+        .setTokenServerUri(tokenServer1)
+        .build();
+    UserCredentials otherCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(httpTransportFactory)
+        .setTokenServerUri(tokenServer2)
+        .build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -266,8 +369,15 @@ public class UserCredentialsTest extends BaseSerializationTest {
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, null);
     final URI tokenServer = URI.create("https://foo.com/bar");
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    OAuth2Credentials credentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN,
-        accessToken, transportFactory, tokenServer);
+    UserCredentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(transportFactory)
+        .setTokenServerUri(tokenServer)
+        .build();
+
     String expectedToString = String.format(
         "UserCredentials{requestMetadata=%s, temporaryAccess=%s, clientId=%s, refreshToken=%s, "
             + "tokenServerUri=%s, transportFactoryClassName=%s}",
@@ -286,10 +396,22 @@ public class UserCredentialsTest extends BaseSerializationTest {
     final URI tokenServer = URI.create("https://foo.com/bar");
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, null);
-    OAuth2Credentials credentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, accessToken, transportFactory, tokenServer);
-    OAuth2Credentials otherCredentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, accessToken, transportFactory, tokenServer);
+    UserCredentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(transportFactory)
+        .setTokenServerUri(tokenServer)
+        .build();
+    UserCredentials otherCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(transportFactory)
+        .setTokenServerUri(tokenServer)
+        .build();
     assertEquals(credentials.hashCode(), otherCredentials.hashCode());
   }
 
@@ -298,8 +420,14 @@ public class UserCredentialsTest extends BaseSerializationTest {
     final URI tokenServer = URI.create("https://foo.com/bar");
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, null);
-    UserCredentials credentials = new UserCredentials(
-        CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, accessToken, transportFactory, tokenServer);
+    UserCredentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(transportFactory)
+        .setTokenServerUri(tokenServer)
+        .build();
     UserCredentials deserializedCredentials = serializeAndDeserialize(credentials);
     assertEquals(credentials, deserializedCredentials);
     assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());


### PR DESCRIPTION
- Add inner Builder class to each data container type classes
- Add `of` method of classes with single parameter constructor
- Update tests

TODO: Switch the rest of the auth lib to builder pattern