### PR TITLE
Fix NPE deserializing ServiceAccountCredentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -60,6 +60,7 @@ import com.google.common.collect.ImmutableSet;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.URI;
@@ -516,6 +517,13 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
           "Error signing service account access token request with private key.", e);
     }
     return assertion;
+  }
+
+  @SuppressWarnings("unused")
+  private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
+    // properly deserialize the transient transportFactory
+    input.defaultReadObject();
+    transportFactory = newInstance(transportFactoryClassName);
   }
 
   public static Builder newBuilder() {

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -616,11 +616,14 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
         SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, transportFactory,
         tokenServer);
+
     ServiceAccountCredentials deserializedCredentials = serializeAndDeserialize(credentials);
     assertEquals(credentials, deserializedCredentials);
     assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());
     assertEquals(credentials.toString(), deserializedCredentials.toString());
     assertSame(deserializedCredentials.clock, Clock.SYSTEM);
+    assertEquals(MockTokenServerTransportFactory.class,
+        deserializedCredentials.toBuilder().getHttpTransportFactory().getClass());
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -616,7 +616,6 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
         SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, transportFactory,
         tokenServer);
-
     ServiceAccountCredentials deserializedCredentials = serializeAndDeserialize(credentials);
     assertEquals(credentials, deserializedCredentials);
     assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());


### PR DESCRIPTION
Deserialization of ServiceAccoutnCredentials broke in 0.7.0 via this commit:
https://github.com/google/google-auth-library-java/commit/432ee7e507e3dfa730a5001a2e561cd65e0ba721#diff-e186a7a41155398a3502025e16ac1508L479

It removed the java deserialization hook readObject to properly deserialize the transient transportFactory field.

This PR reverts that change and adds a test