### PR TITLE
Fixing version to 0.8.1-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Open source authentication client library for Java.
 [![Build Status](https://travis-ci.org/google/google-auth-library-java.svg?branch=master)](https://travis-ci.org/google/google-auth-library-java.svg)
 [![Maven](https://img.shields.io/maven-central/v/com.google.auth/google-auth-library-credentials.svg)](https://img.shields.io/maven-central/v/com.google.auth/google-auth-library-credentials.svg)
 
--  [API Documentation] (https://google.github.io/google-auth-library-java/releases/0.7.1/apidocs)
+-  [API Documentation] (https://google.github.io/google-auth-library-java/releases/0.8.0/apidocs)
 
 This project consists of 3 artifacts:
 
@@ -30,16 +30,16 @@ If you are using Maven, add this to your pom.xml file (notice that you can repla
 <dependency>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-oauth2-http</artifactId>
-  <version>0.7.1</version>
+  <version>0.8.0</version>
 </dependency>
 ```
 If you are using Gradle, add this to your dependencies
 ```Groovy
-compile 'com.google.auth:google-auth-library-oauth2-http:0.7.1'
+compile 'com.google.auth:google-auth-library-oauth2-http:0.8.0'
 ```
 If you are using SBT, add this to your dependencies
 ```Scala
-libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.7.1"
+libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.8.0"
 ```
 
 google-auth-library-credentials

--- a/appengine/pom.xml
+++ b/appengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.7.2-SNAPSHOT</version>
+    <version>0.8.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/credentials/pom.xml
+++ b/credentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.7.2-SNAPSHOT</version>
+    <version>0.8.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.7.2-SNAPSHOT</version>
+    <version>0.8.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-parent</artifactId>
-  <version>0.7.2-SNAPSHOT</version>
+  <version>0.8.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Google Auth Library for Java</name>
   <description>Client libraries providing authentication and


### PR DESCRIPTION
The PR to bump the version to 0.8.0
(https://github.com/google/google-auth-library-java/pull/126)
was not merged before additional commits were merged, so it had to
be closed out. This PR bumps to the proper SNAPSHOT version for the
next release. Commit 0fab63c corresponds to the actual 0.8.0 release.