### PR TITLE
Surface cleanup

### DIFF
--- a/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
+++ b/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
@@ -62,11 +62,19 @@ public class AppEngineCredentials extends GoogleCredentials implements ServiceAc
 
   private transient AppIdentityService appIdentityService;
 
+  /**
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
+   */
   @Deprecated
   public AppEngineCredentials(Collection<String> scopes) {
     this(scopes, null);
   }
 
+  /**
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
+   */
   @Deprecated
   public AppEngineCredentials(Collection<String> scopes, AppIdentityService appIdentityService) {
     this.scopes = scopes == null ? ImmutableSet.<String>of() : ImmutableList.copyOf(scopes);

--- a/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
+++ b/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
@@ -63,8 +63,8 @@ public class AppEngineCredentials extends GoogleCredentials implements ServiceAc
   private transient AppIdentityService appIdentityService;
 
   /**
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public AppEngineCredentials(Collection<String> scopes) {
@@ -72,8 +72,8 @@ public class AppEngineCredentials extends GoogleCredentials implements ServiceAc
   }
 
   /**
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public AppEngineCredentials(Collection<String> scopes, AppIdentityService appIdentityService) {

--- a/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
+++ b/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
@@ -74,7 +74,10 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
 
     MockAppIdentityService appIdentity = new MockAppIdentityService();
     appIdentity.setAccessTokenText(expectedAccessToken);
-    Credentials credentials = new AppEngineCredentials(SCOPES, appIdentity);
+    Credentials credentials = AppEngineCredentials.newBuilder()
+        .setScopes(SCOPES)
+        .setAppIdentityService(appIdentity)
+        .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 

--- a/oauth2_http/java/com/google/auth/oauth2/ClientId.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ClientId.java
@@ -57,6 +57,19 @@ public class ClientId {
   private final String clientSecret;
 
   /**
+   * Constructs a client ID from an explicit ID and secret.
+   *
+   * <p>Note: Direct use of this factory method in application code is not recommended to avoid
+   * having secrets or values that need to be updated in source code.
+   *
+   * @param clientId Text identifier of the Client ID.
+   * @param clientSecret Secret to associated with the Client ID.
+   */
+  public static ClientId of(String clientId, String clientSecret) {
+    return new ClientId(clientId, clientSecret);
+  }
+
+  /**
    * Constructs a Client ID from JSON from a downloaded file.
    *
    * @param json The JSON from the downloaded file.
@@ -122,6 +135,8 @@ public class ClientId {
    *
    * @param clientId Text identifier of the Client ID.
    * @param clientSecret Secret to associated with the Client ID.
+   * @deprecated Use {@link #of(String, String)} instead. This constructor will either be deleted
+   *             or made private in a later version.
    */
   @Deprecated
   public ClientId(String clientId, String clientSecret) {

--- a/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
@@ -63,10 +63,22 @@ public class CloudShellCredentials extends GoogleCredentials {
 
   private final int authPort;
 
+  /**
+   * @deprecated Use {@link #create(int)} instead. This method will be deleted in a later version.
+   */
+  @Deprecated
   public static CloudShellCredentials of(int authPort) {
+    return create(authPort);
+  }
+
+  public static CloudShellCredentials create(int authPort) {
     return CloudShellCredentials.newBuilder().setAuthPort(authPort).build();
   }
 
+  /**
+   * @deprecated Use {@link #create(int)} instead. This constructor will either be deleted or
+   *             made private in a later version.
+   */
   @Deprecated
   public CloudShellCredentials(int authPort) {
     this.authPort = authPort;

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -87,13 +87,19 @@ public class ComputeEngineCredentials extends GoogleCredentials {
    *
    * @param transportFactory The Http transport factory
    * @return the credential instance
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             method will be deleted in a later version.
    */
+  @Deprecated
   public static ComputeEngineCredentials of(HttpTransportFactory transportFactory) {
     return ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
   }
 
   /**
    * Constructor with minimum information and default behavior.
+   *
+   * @deprecated Use {@link #create()} instead. This constructor will either be deleted or
+   *             made private in a later version.
    */
   @Deprecated
   public ComputeEngineCredentials() {
@@ -105,12 +111,21 @@ public class ComputeEngineCredentials extends GoogleCredentials {
    *
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
    */
   @Deprecated
   public ComputeEngineCredentials(HttpTransportFactory transportFactory) {
     this.transportFactory = firstNonNull(transportFactory,
         getFromServiceLoader(HttpTransportFactory.class, OAuth2Utils.HTTP_TRANSPORT_FACTORY));
     this.transportFactoryClassName = this.transportFactory.getClass().getName();
+  }
+
+  /**
+   * Create a new ComputeEngineCredentials instance.
+   */
+  public static ComputeEngineCredentials create() {
+    return new ComputeEngineCredentials(null);
   }
 
   /**

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -87,8 +87,8 @@ public class ComputeEngineCredentials extends GoogleCredentials {
    *
    * @param transportFactory The Http transport factory
    * @return the credential instance
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             method will be deleted in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public static ComputeEngineCredentials of(HttpTransportFactory transportFactory) {
@@ -96,7 +96,7 @@ public class ComputeEngineCredentials extends GoogleCredentials {
   }
 
   /**
-   * Constructor with minimum information and default behavior.
+   * Create a new ComputeEngineCredentials instance with default behavior.
    *
    * @deprecated Use {@link #create()} instead. This constructor will either be deleted or
    *             made private in a later version.
@@ -111,8 +111,8 @@ public class ComputeEngineCredentials extends GoogleCredentials {
    *
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public ComputeEngineCredentials(HttpTransportFactory transportFactory) {
@@ -122,7 +122,7 @@ public class ComputeEngineCredentials extends GoogleCredentials {
   }
 
   /**
-   * Create a new ComputeEngineCredentials instance.
+   * Create a new ComputeEngineCredentials instance with default behavior.
    */
   public static ComputeEngineCredentials create() {
     return new ComputeEngineCredentials(null);

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -242,7 +242,7 @@ class DefaultCredentialsProvider {
   private GoogleCredentials tryGetCloudShellCredentials() {
     String port = getEnv(CLOUD_SHELL_ENV_VAR);
     if (port != null) {
-      return new CloudShellCredentials(Integer.parseInt(port));
+      return CloudShellCredentials.create(Integer.parseInt(port));
     } else {
       return null;
     }
@@ -270,7 +270,7 @@ class DefaultCredentialsProvider {
         ComputeEngineCredentials.runningOnComputeEngine(transportFactory, this);
     checkedComputeEngine = true;
     if (runningOnComputeEngine) {
-      return new ComputeEngineCredentials(transportFactory);
+      return ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     }
     return null;
   }

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -58,8 +58,21 @@ public class GoogleCredentials extends OAuth2Credentials {
    *
    * @param accessToken the access token
    * @return the credentials instance
+   * @deprecated Use {@link #create(AccessToken)} instead. This method will be deleted in a later
+   *             version.
    */
+  @Deprecated
   public static GoogleCredentials of(AccessToken accessToken) {
+    return create(accessToken);
+  }
+
+  /**
+   * Returns the credentials instance from the given access token.
+   *
+   * @param accessToken the access token
+   * @return the credentials instance
+   */
+  public static GoogleCredentials create(AccessToken accessToken) {
     return GoogleCredentials.newBuilder().setAccessToken(accessToken).build();
   }
 
@@ -176,6 +189,8 @@ public class GoogleCredentials extends OAuth2Credentials {
    * Constructor with explicit access token.
    *
    * @param accessToken Initial or temporary access token.
+   * @deprecated Use {@link #create(AccessToken)} instead. This constructor will either be deleted
+   *             or made protected/private in a later version.
    **/
   @Deprecated
   public GoogleCredentials(AccessToken accessToken) {

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -77,8 +77,21 @@ public class OAuth2Credentials extends Credentials {
    *
    * @param accessToken the access token
    * @return the credentials instance
+   * @deprecated Use {@link #create(AccessToken)} instead. This method will be deleted in a later
+   *             version.
    */
+  @Deprecated
   public static OAuth2Credentials of(AccessToken accessToken) {
+    return create(accessToken);
+  }
+
+  /**
+   * Returns the credentials instance from the given access token.
+   *
+   * @param accessToken the access token
+   * @return the credentials instance
+   */
+  public static OAuth2Credentials create(AccessToken accessToken) {
     return OAuth2Credentials.newBuilder().setAccessToken(accessToken).build();
   }
 
@@ -93,6 +106,8 @@ public class OAuth2Credentials extends Credentials {
    * Constructor with explicit access token.
    *
    * @param accessToken Initial or temporary access token.
+   * @deprecated Use {@link #create(AccessToken)} instead. This constructor will either be deleted
+   *             or made private in a later version.
    **/
   @Deprecated
   public OAuth2Credentials(AccessToken accessToken) {
@@ -252,15 +267,15 @@ public class OAuth2Credentials extends Credentials {
     return Objects.hash(requestMetadata, temporaryAccess);
   }
 
-  protected ToStringHelper toStringHelper() {
-    return MoreObjects.toStringHelper(this)
-        .add("requestMetadata", requestMetadata)
-        .add("temporaryAccess", temporaryAccess);
+  protected Map<String, List<String>> getRequestMetadataInternal() {
+    return requestMetadata;
   }
 
   @Override
   public String toString() {
-    return toStringHelper().toString();
+    return MoreObjects.toStringHelper(this)
+        .add("requestMetadata", requestMetadata)
+        .add("temporaryAccess", temporaryAccess).toString();
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -110,8 +110,8 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
    * @param privateKeyId Private key identifier for the service account. May be null.
    * @param scopes Scope strings for the APIs to be called. May be null or an empty collection,
    *        which results in a credential that must have createScoped called before use.
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public ServiceAccountCredentials(
@@ -132,8 +132,8 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.
    * @param tokenServerUri URI of the end point that provides tokens.
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public ServiceAccountCredentials(

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -110,6 +110,8 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
    * @param privateKeyId Private key identifier for the service account. May be null.
    * @param scopes Scope strings for the APIs to be called. May be null or an empty collection,
    *        which results in a credential that must have createScoped called before use.
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
    */
   @Deprecated
   public ServiceAccountCredentials(
@@ -130,6 +132,8 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.
    * @param tokenServerUri URI of the end point that provides tokens.
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
    */
   @Deprecated
   public ServiceAccountCredentials(

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -91,6 +91,8 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    * @param clientEmail Client email address of the service account from the console.
    * @param privateKey RSA private key object for the service account.
    * @param privateKeyId Private key identifier for the service account. May be null.
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
    */
   @Deprecated
   public ServiceAccountJwtAccessCredentials(
@@ -106,6 +108,8 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    * @param privateKey RSA private key object for the service account.
    * @param privateKeyId Private key identifier for the service account. May be null.
    * @param defaultAudience Audience to use if not provided by transport. May be null.
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
    */
   @Deprecated
   public ServiceAccountJwtAccessCredentials(String clientId, String clientEmail,
@@ -410,6 +414,11 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
 
     public Builder setPrivateKeyId(String privateKeyId) {
       this.privateKeyId = privateKeyId;
+      return this;
+    }
+
+    public Builder setDefaultAudience(URI defaultAudience) {
+      this.defaultAudience = defaultAudience;
       return this;
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -91,8 +91,8 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    * @param clientEmail Client email address of the service account from the console.
    * @param privateKey RSA private key object for the service account.
    * @param privateKeyId Private key identifier for the service account. May be null.
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public ServiceAccountJwtAccessCredentials(
@@ -108,8 +108,8 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    * @param privateKey RSA private key object for the service account.
    * @param privateKeyId Private key identifier for the service account. May be null.
    * @param defaultAudience Audience to use if not provided by transport. May be null.
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public ServiceAccountJwtAccessCredentials(String clientId, String clientEmail,

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -75,6 +75,8 @@ public class UserAuthorizer {
    * @param clientId Client ID to identify the OAuth2 consent prompt.
    * @param scopes OAUth2 scopes defining the user consent.
    * @param tokenStore Implementation of component for long term storage of tokens.
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
    */
   @Deprecated
   public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore) {
@@ -88,6 +90,8 @@ public class UserAuthorizer {
    * @param scopes OAUth2 scopes defining the user consent.
    * @param tokenStore Implementation of component for long term storage of tokens.
    * @param callbackUri URI for implementation of the OAuth2 web callback.
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
    */
   @Deprecated
   public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore, URI callbackUri) {
@@ -105,6 +109,8 @@ public class UserAuthorizer {
    *        tokens.
    * @param tokenServerUri URI of the end point that provides tokens.
    * @param userAuthUri URI of the Web UI for user consent.
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
    */
   @Deprecated
   public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore,
@@ -223,8 +229,14 @@ public class UserAuthorizer {
     AccessToken accessToken = new AccessToken(accessTokenValue, expirationTime);
     String refreshToken = OAuth2Utils.validateOptionalString(
         tokenJson, "refresh_token", TOKEN_STORE_ERROR);
-    UserCredentials credentials = new UserCredentials(clientId.getClientId(),
-        clientId.getClientSecret(), refreshToken, accessToken, transportFactory, tokenServerUri);
+    UserCredentials credentials = UserCredentials.newBuilder()
+        .setClientId(clientId.getClientId())
+        .setClientSecret(clientId.getClientSecret())
+        .setRefreshToken(refreshToken)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(transportFactory)
+        .setTokenServerUri(tokenServerUri)
+        .build();
     monitorCredentials(userId, credentials);
     return credentials;
   }
@@ -264,8 +276,14 @@ public class UserAuthorizer {
     String refreshToken = OAuth2Utils.validateOptionalString(
         parsedTokens, "refresh_token", FETCH_TOKEN_ERROR);
 
-    return new UserCredentials(clientId.getClientId(), clientId.getClientSecret(), refreshToken,
-        accessToken, transportFactory, tokenServerUri);
+    return UserCredentials.newBuilder()
+        .setClientId(clientId.getClientId())
+        .setClientSecret(clientId.getClientSecret())
+        .setRefreshToken(refreshToken)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(transportFactory)
+        .setTokenServerUri(tokenServerUri)
+        .build();
   }
 
   /**

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -75,8 +75,8 @@ public class UserAuthorizer {
    * @param clientId Client ID to identify the OAuth2 consent prompt.
    * @param scopes OAUth2 scopes defining the user consent.
    * @param tokenStore Implementation of component for long term storage of tokens.
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore) {
@@ -90,8 +90,8 @@ public class UserAuthorizer {
    * @param scopes OAUth2 scopes defining the user consent.
    * @param tokenStore Implementation of component for long term storage of tokens.
    * @param callbackUri URI for implementation of the OAuth2 web callback.
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore, URI callbackUri) {
@@ -109,8 +109,8 @@ public class UserAuthorizer {
    *        tokens.
    * @param tokenServerUri URI of the end point that provides tokens.
    * @param userAuthUri URI of the Web UI for user consent.
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore,

--- a/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -77,8 +77,8 @@ public class UserCredentials extends GoogleCredentials {
    * @param clientId Client ID of the credential from the console.
    * @param clientSecret Client ID of the credential from the console.
    * @param refreshToken A refresh token resulting from a OAuth2 consent flow.
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public UserCredentials(String clientId, String clientSecret, String refreshToken) {
@@ -92,8 +92,8 @@ public class UserCredentials extends GoogleCredentials {
    * @param clientSecret Client ID of the credential from the console.
    * @param refreshToken A refresh token resulting from a OAuth2 consent flow.
    * @param accessToken Initial or temporary access token.
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public UserCredentials(
@@ -112,8 +112,8 @@ public class UserCredentials extends GoogleCredentials {
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.
    * @param tokenServerUri URI of the end point that provides tokens.
-   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
-   *             constructor will either be deleted or made private in a later version.
+   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
+   *             private in a later version.
    */
   @Deprecated
   public UserCredentials(String clientId, String clientSecret, String refreshToken,

--- a/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -45,6 +45,7 @@ import com.google.api.client.util.GenericData;
 import com.google.api.client.util.Preconditions;
 import com.google.auth.http.HttpTransportFactory;
 
+import com.google.common.base.MoreObjects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -76,6 +77,8 @@ public class UserCredentials extends GoogleCredentials {
    * @param clientId Client ID of the credential from the console.
    * @param clientSecret Client ID of the credential from the console.
    * @param refreshToken A refresh token resulting from a OAuth2 consent flow.
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
    */
   @Deprecated
   public UserCredentials(String clientId, String clientSecret, String refreshToken) {
@@ -89,6 +92,8 @@ public class UserCredentials extends GoogleCredentials {
    * @param clientSecret Client ID of the credential from the console.
    * @param refreshToken A refresh token resulting from a OAuth2 consent flow.
    * @param accessToken Initial or temporary access token.
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
    */
   @Deprecated
   public UserCredentials(
@@ -107,6 +112,8 @@ public class UserCredentials extends GoogleCredentials {
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.
    * @param tokenServerUri URI of the end point that provides tokens.
+   * @deprecated Use {@link #newBuilder()} instead to construct an instance using the builder. This
+   *             constructor will either be deleted or made private in a later version.
    */
   @Deprecated
   public UserCredentials(String clientId, String clientSecret, String refreshToken,
@@ -141,7 +148,14 @@ public class UserCredentials extends GoogleCredentials {
       throw new IOException("Error reading user credential from JSON, "
           + " expecting 'client_id', 'client_secret' and 'refresh_token'.");
     }
-    return new UserCredentials(clientId, clientSecret, refreshToken, null, transportFactory, null);
+    return UserCredentials.newBuilder()
+        .setClientId(clientId)
+        .setClientSecret(clientSecret)
+        .setRefreshToken(refreshToken)
+        .setAccessToken(null)
+        .setHttpTransportFactory(transportFactory)
+        .setTokenServerUri(null)
+        .build();
   }
 
   /**
@@ -252,7 +266,9 @@ public class UserCredentials extends GoogleCredentials {
 
   @Override
   public String toString() {
-    return toStringHelper()
+    return MoreObjects.toStringHelper(this)
+        .add("requestMetadata", getRequestMetadataInternal())
+        .add("temporaryAccess", getAccessToken())
         .add("clientId", clientId)
         .add("refreshToken", refreshToken)
         .add("tokenServerUri", tokenServerUri)

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -122,8 +122,10 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
   @Test
   public void equals_true() throws IOException {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
-    ComputeEngineCredentials credentials = new ComputeEngineCredentials(transportFactory);
-    ComputeEngineCredentials otherCredentials = new ComputeEngineCredentials(transportFactory);
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    ComputeEngineCredentials otherCredentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     assertTrue(credentials.equals(otherCredentials));
     assertTrue(otherCredentials.equals(credentials));
   }
@@ -158,8 +160,9 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory serverTransportFactory =
         new MockMetadataServerTransportFactory();
     ComputeEngineCredentials credentials =
-        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();    ComputeEngineCredentials otherCredentials =
-        new ComputeEngineCredentials(serverTransportFactory);
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();
+    ComputeEngineCredentials otherCredentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();
     assertEquals(credentials.hashCode(), otherCredentials.hashCode());
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
@@ -400,7 +400,7 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     OAuth2Credentials credentials = OAuth2Credentials.newBuilder()
         .setAccessToken(new AccessToken(accessToken, null))
         .build();
-    OAuth2Credentials otherCredentials = new OAuth2Credentials(new AccessToken(accessToken, null));
+    OAuth2Credentials otherCredentials = OAuth2Credentials.create(new AccessToken(accessToken, null));
     assertEquals(credentials.hashCode(), otherCredentials.hashCode());
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -193,8 +193,13 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void getRequestMetadata_blocking_defaultURI_hasJwtAccess() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    Credentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
+    Credentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata();
 
@@ -240,8 +245,13 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void getRequestMetadata_async_defaultURI_hasJwtAccess() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    Credentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
+    Credentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
     MockExecutor executor = new MockExecutor();
     MockRequestMetadataCallback callback = new MockRequestMetadataCallback();
 
@@ -301,10 +311,20 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void equals_true() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountJwtAccessCredentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
-    ServiceAccountJwtAccessCredentials otherCredentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
+    ServiceAccountJwtAccessCredentials otherCredentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
     assertTrue(credentials.equals(otherCredentials));
     assertTrue(otherCredentials.equals(credentials));
   }
@@ -312,10 +332,20 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void equals_false_clientId() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountJwtAccessCredentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
-    ServiceAccountJwtAccessCredentials otherCredentials = new ServiceAccountJwtAccessCredentials(
-        "otherClientId", SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
+    ServiceAccountJwtAccessCredentials otherCredentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId("otherClientId")
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -323,10 +353,20 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void equals_false_email() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountJwtAccessCredentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
-    ServiceAccountJwtAccessCredentials otherCredentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, "otherClientEmail", privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
+    ServiceAccountJwtAccessCredentials otherCredentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail("otherClientEmail")
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -334,10 +374,20 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void equals_false_keyId() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountJwtAccessCredentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
-    ServiceAccountJwtAccessCredentials otherCredentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, "otherKeyId", CALL_URI);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
+    ServiceAccountJwtAccessCredentials otherCredentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId("otherKeyId")
+        .setDefaultAudience(CALL_URI)
+        .build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -346,10 +396,20 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   public void equals_false_callUri() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     final URI otherCallUri = URI.create("https://foo.com/bar");
-    ServiceAccountJwtAccessCredentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
-    ServiceAccountJwtAccessCredentials otherCredentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, otherCallUri);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
+    ServiceAccountJwtAccessCredentials otherCredentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(otherCallUri)
+        .build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -357,8 +417,13 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void toString_containsFields() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountJwtAccessCredentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
     String expectedToString = String.format(
         "ServiceAccountJwtAccessCredentials{clientId=%s, clientEmail=%s, privateKeyId=%s, "
             + "defaultAudience=%s}",
@@ -372,18 +437,33 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void hashCode_equals() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountJwtAccessCredentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
-    ServiceAccountJwtAccessCredentials otherCredentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
+    ServiceAccountJwtAccessCredentials otherCredentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
     assertEquals(credentials.hashCode(), otherCredentials.hashCode());
   }
 
   @Test
   public void serialize() throws IOException, ClassNotFoundException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountJwtAccessCredentials credentials = new ServiceAccountJwtAccessCredentials(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, privateKey, SA_PRIVATE_KEY_ID, CALL_URI);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(CALL_URI)
+        .build();
     ServiceAccountJwtAccessCredentials deserializedCredentials =
         serializeAndDeserialize(credentials);
     assertEquals(credentials, deserializedCredentials);

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
@@ -65,7 +65,7 @@ public class UserAuthorizerTest {
   private static final Long EXPIRATION_TIME = 504000300L;
   private static final AccessToken ACCESS_TOKEN =
       new AccessToken(ACCESS_TOKEN_VALUE, new Date(EXPIRATION_TIME));
-  private static final ClientId CLIENT_ID = new ClientId(CLIENT_ID_VALUE, CLIENT_SECRET);
+  private static final ClientId CLIENT_ID = ClientId.of(CLIENT_ID_VALUE, CLIENT_SECRET);
   private static final String SCOPE = "dummy.scope";
   private static final Collection<String> SCOPES = Collections.singletonList(SCOPE);
   private static final String USER_ID = "foo@bar.com";

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
@@ -278,10 +278,22 @@ public class UserCredentialsTest extends BaseSerializationTest {
     final URI tokenServer1 = URI.create("https://foo1.com/bar");
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, null);
     MockHttpTransportFactory httpTransportFactory = new MockHttpTransportFactory();
-    OAuth2Credentials credentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN,
-        accessToken, httpTransportFactory, tokenServer1);
-    OAuth2Credentials otherCredentials = new UserCredentials(CLIENT_ID, CLIENT_SECRET,
-        "otherRefreshToken", accessToken, httpTransportFactory, tokenServer1);
+    OAuth2Credentials credentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken(REFRESH_TOKEN)
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(httpTransportFactory)
+        .setTokenServerUri(tokenServer1)
+        .build();
+    OAuth2Credentials otherCredentials = UserCredentials.newBuilder()
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .setRefreshToken("otherRefreshToken")
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(httpTransportFactory)
+        .setTokenServerUri(tokenServer1)
+        .build();
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }


### PR DESCRIPTION
- Removing Guava from surface
- Renaming of() methods to create() (using deprecation)
- Adding @deprecated javadoc to explain changes that callers need to make
- Migrating internal usage of deprecated methods that was missed previously