### PR TITLE
Modification to reading GOOGLE_APPLICATION_CREDENTIALS 

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -40,8 +40,6 @@ import java.lang.reflect.Method;
 import java.security.AccessControlException;
 import java.util.Collections;
 import java.util.Locale;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Provides the Application Default Credential from the environment.
@@ -124,8 +122,6 @@ class DefaultCredentialsProvider {
 
   private final GoogleCredentials getDefaultCredentialsUnsynchronized(
       HttpTransportFactory transportFactory) throws IOException {
-
-    final Logger LOGGER = Logger.getLogger(GoogleCredentials.class.getName());
 
     // First try the environment variable
     GoogleCredentials credentials = null;

--- a/oauth2_http/javatests/com/google/auth/TestUtils.java
+++ b/oauth2_http/javatests/com/google/auth/TestUtils.java
@@ -42,10 +42,7 @@ import com.google.auth.http.AuthHttpConstants;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.io.IOException;
+import java.io.*;
 import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.List;
@@ -88,6 +85,24 @@ public class TestUtils {
     } catch (UnsupportedEncodingException e) {
       throw new RuntimeException("Unexpected encoding exception", e);
     }
+  }
+
+  public static String inputStreamToString(InputStream in) {
+    try {
+      BufferedInputStream bis = new BufferedInputStream(in);
+      ByteArrayOutputStream buf = new ByteArrayOutputStream();
+      int result = bis.read();
+      while (result != -1) {
+        byte b = (byte) result;
+        buf.write(b);
+        result = bis.read();
+      }
+
+      return buf.toString();
+    } catch (IOException e) {
+      throw new RuntimeException("Unexpected IO exception", e);
+    }
+
   }
 
   public static Map<String, String> parseQuery(String query) throws IOException {

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -54,11 +54,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.security.AccessControlException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -284,6 +281,18 @@ public class DefaultCredentialsProviderTest {
       assertTrue(message.contains(DefaultCredentialsProvider.CREDENTIAL_ENV_VAR));
       assertTrue(message.contains(invalidPath));
     }
+  }
+
+  @Test
+  public void getDefaultCredentials_envMissingFile_providesJSON() throws IOException {
+    InputStream userStream =
+            UserCredentialsTest.writeUserStream(USER_CLIENT_ID, USER_CLIENT_SECRET, REFRESH_TOKEN);
+    TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
+
+    testProvider.setEnv(DefaultCredentialsProvider.CREDENTIAL_ENV_VAR, TestUtils.inputStreamToString(userStream));
+
+    testUserProvidesToken(
+            testProvider, USER_CLIENT_ID, USER_CLIENT_SECRET, REFRESH_TOKEN);
   }
 
   @Test


### PR DESCRIPTION
Currently, an issue I have using Google Auth is that it requires `GOOGLE_APPLICATION_CREDENTIALS` as an environment variable, and point to the file with credentials.

While using this in Docker, it means that we would have to either:
1. Bake the credentials in the image
2. Mount the file on the image during run-time.

However, if we make a slight modification so that: `GOOGLE_APPLICATION_CREDENTIALS` can also be the JSON string of the file contents...we no longer need to do that.

Proposed changes:
1. Try reading GOOGLE_APPLICATION_CREDENTIALS as a file...
2. If (1) fails: before throwing an error...it will try reading GOOGLE_APPLICATION_CREDENTIALS as a JSON string.