### PR TITLE
make ComputeEngineCredentials support scopes

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -251,7 +251,7 @@ public class ComputeEngineCredentials extends GoogleCredentials {
 
   @Override
   public int hashCode() {
-    return Objects.hash(transportFactoryClassName, scopes, scopeRequired);
+    return Objects.hash(transportFactoryClassName, scopes, scopesRequired);
   }
 
   @Override
@@ -259,7 +259,7 @@ public class ComputeEngineCredentials extends GoogleCredentials {
     return MoreObjects.toStringHelper(this)
         .add("transportFactoryClassName", transportFactoryClassName)
         .add("scopes", scopes)
-        .add("scopesRequired", scopeRequired)
+        .add("scopesRequired", scopesRequired)
         .toString();
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -117,7 +117,6 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     assertThat(credentials.createScopedRequired()).isTrue();
-
     GoogleCredentials scopedCredentials = credentials.createScoped(SCOPES);
     assertThat(scopedCredentials.createScopedRequired()).isFalse();
   }
@@ -182,8 +181,8 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory serverTransportFactory =
         new MockMetadataServerTransportFactory();
     String expectedToString =
-        String.format("ComputeEngineCredentials{transportFactoryClassName=%s}",
-            MockMetadataServerTransportFactory.class.getName());
+        String.format("ComputeEngineCredentials{transportFactoryClassName=%s, scopes=%s, scopesRequired=%s}",
+            MockMetadataServerTransportFactory.class.getName(), "[]", "true");
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();
     assertEquals(expectedToString, credentials.toString());

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -65,6 +65,12 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>0.39</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
 - add fields scope and scopeRequired
 - make changes to constructors and builders
 - update toString(), equals() and hashCode()
 - add test cases
 - fixes #148 