### PR TITLE
Add caching for JWT tokens

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -48,6 +48,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 
 import com.google.common.base.Throwables;
+import com.google.common.base.Ticker;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -80,7 +81,9 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
 
   private static final long serialVersionUID = -7274955171379494197L;
   static final String JWT_ACCESS_PREFIX = OAuth2Utils.BEARER_PREFIX;
-  private static final int LIFE_SPAN_SECS = 3600;
+  @VisibleForTesting
+  static final long LIFE_SPAN_SECS = TimeUnit.HOURS.toSeconds(1);
+
 
   private final String clientId;
   private final String clientEmail;
@@ -243,6 +246,14 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
     return CacheBuilder.newBuilder()
         .maximumSize(100)
         .expireAfterWrite(LIFE_SPAN_SECS - 10, TimeUnit.SECONDS)
+        .ticker(
+            new Ticker() {
+              @Override
+              public long read() {
+                return TimeUnit.MILLISECONDS.toNanos(clock.currentTimeMillis());
+              }
+            }
+        )
         .build(
             new CacheLoader<URI, String>() {
               @Override

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -84,7 +84,6 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   @VisibleForTesting
   static final long LIFE_SPAN_SECS = TimeUnit.HOURS.toSeconds(1);
 
-
   private final String clientId;
   private final String clientEmail;
   private final PrivateKey privateKey;
@@ -245,7 +244,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   private LoadingCache<URI, String> createCache() {
     return CacheBuilder.newBuilder()
         .maximumSize(100)
-        .expireAfterWrite(LIFE_SPAN_SECS - 10, TimeUnit.SECONDS)
+        .expireAfterWrite(LIFE_SPAN_SECS - 300, TimeUnit.SECONDS)
         .ticker(
             new Ticker() {
               @Override

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -317,6 +317,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
       throw new IllegalStateException("generateJwtAccess threw an unchecked exception that couldn't be rethrown", e);
     }
   }
+
   private String generateJwtAccess(URI uri) throws IOException {
     JsonWebSignature.Header header = new JsonWebSignature.Header();
     header.setAlgorithm("RS256");

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.6</java.version>
     <project.google.http.version>1.19.0</project.google.http.version>
-    <project.junit.version>4.8.2</project.junit.version>
+    <project.junit.version>4.12</project.junit.version>
     <project.guava.version>19.0</project.guava.version>
     <project.appengine.version>1.9.34</project.appengine.version>
   </properties>


### PR DESCRIPTION
Use guava's LoadingCache to cache JWT tokens. This should address performance for both clientside & serverside:
- Avoid the need for the client to recompute the signature
- Allows the serverside to cache tokens

Benchmarks (n1-standard-4):
- Generating a JWT token takes about 7~8ms (p50) on an idle machine
- Additionally, the newly generated tokens will add 9ms to p99 processing on serverside (for Cloud Bigtable)
- For reference, Cloud Bigtable has a 5ms response @ p99 using cached JWTs or OAuth tokens.
- Combined, the clientside & serverside overhead for using uncached JWT tokens triples Cloud Bigtable's p99 latency.

Merging this PR will have a significant impact on the consistency of Cloud Bigtable's performance (and other low latency products as well).