### PR TITLE
Read token_uri from service account JSON.

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -64,6 +64,7 @@ import java.io.ObjectInputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
@@ -191,6 +192,15 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
     String privateKeyPkcs8 = (String) json.get("private_key");
     String privateKeyId = (String) json.get("private_key_id");
     String projectId = (String) json.get("project_id");
+    String tokenServerUriStringFromCreds = (String) json.get("token_uri");
+    URI tokenServerUriFromCreds = null;
+    try {
+      if (tokenServerUriStringFromCreds != null) {
+        tokenServerUriFromCreds = new URI(tokenServerUriStringFromCreds);
+      }
+    } catch (URISyntaxException e) {
+      throw new IOException("Token server URI specified in 'token_uri' could not be parsed.");
+    }
     if (clientId == null || clientEmail == null
         || privateKeyPkcs8 == null || privateKeyId == null) {
       throw new IOException("Error reading service account credential from JSON, "
@@ -198,7 +208,7 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
     }
 
     return fromPkcs8(clientId, clientEmail, privateKeyPkcs8, privateKeyId, null, transportFactory,
-        null, null, projectId);
+        tokenServerUriFromCreds, null, projectId);
   }
 
   /**
@@ -350,7 +360,7 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTime = clock.currentTimeMillis();
-    String assertion = createAssertion(jsonFactory, currentTime);
+    String assertion = createAssertion(jsonFactory, currentTime, tokenServerUri.toString());
 
     GenericData tokenRequest = new GenericData();
     tokenRequest.set("grant_type", GRANT_TYPE);
@@ -447,6 +457,10 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
     return projectId;
   }
 
+  public final URI getTokenServerUri() {
+    return tokenServerUri;
+  }
+
   @Override
   public String getAccount() {
     return getClientEmail();
@@ -498,7 +512,8 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
         && Objects.equals(this.scopes, other.scopes);
   }
 
-  String createAssertion(JsonFactory jsonFactory, long currentTime) throws IOException {
+  String createAssertion(JsonFactory jsonFactory, long currentTime, String audience)
+      throws IOException {
     JsonWebSignature.Header header = new JsonWebSignature.Header();
     header.setAlgorithm("RS256");
     header.setType("JWT");
@@ -506,11 +521,16 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
 
     JsonWebToken.Payload payload = new JsonWebToken.Payload();
     payload.setIssuer(clientEmail);
-    payload.setAudience(OAuth2Utils.TOKEN_SERVER_URI.toString());
     payload.setIssuedAtTimeSeconds(currentTime / 1000);
     payload.setExpirationTimeSeconds(currentTime / 1000 + 3600);
     payload.setSubject(serviceAccountUser);
     payload.put("scope", Joiner.on(' ').join(scopes));
+
+    if (audience == null) {
+      payload.setAudience(OAuth2Utils.TOKEN_SERVER_URI.toString());
+    } else {
+      payload.setAudience(audience);
+    }
 
     String assertion;
     try {


### PR DESCRIPTION
This is important for testing (where we need to e.g. use the staging
Google OAuth server instead of prod) or IoT (where we need to use a
custom IoT token server instead of prod).

This commit is a copy of google-internal change cl/183885510.

Fixes #159.