### PR TITLE
Bump release to 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ If you are using Maven, add this to your pom.xml file (notice that you can repla
 <dependency>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-oauth2-http</artifactId>
-  <version>0.9.1</version>
+  <version>0.10.0</version>
 </dependency>
 ```
 If you are using Gradle, add this to your dependencies
 ```Groovy
-compile 'com.google.auth:google-auth-library-oauth2-http:0.9.1'
+compile 'com.google.auth:google-auth-library-oauth2-http:0.10.0'
 ```
 If you are using SBT, add this to your dependencies
 ```Scala
-libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.9.1"
+libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.10.0"
 ```
 
 ## google-auth-library-credentials

--- a/appengine/pom.xml
+++ b/appengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.10.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/credentials/pom.xml
+++ b/credentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.10.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.10.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-parent</artifactId>
-  <version>0.9.2-SNAPSHOT</version>
+  <version>0.10.0</version>
   <packaging>pom</packaging>
   <name>Google Auth Library for Java</name>
   <description>Client libraries providing authentication and


### PR DESCRIPTION
Changes:
* Read token_uri from service account JSON (#160)
* Add `OAuth2Credentials#refreshIfExpired()` (#163)
* Log warning if default credentials yeids a user token from gcloud sdk (#166)
* `ComputeEngineCredentials` implements `ServiceAccountSigner` (#141)
* Various documentation fixes